### PR TITLE
Add Hugo installation instructions and Brewfile for dependencies

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew "hugo"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ created between human-driven exploration and AI assistance.
 
 ## Writer's Guide
 
+### Install dependencies
+
+Install Hugo on macOS with Homebrew Bundle.
+
+```bash
+brew bundle install
+```
+
 Run `hugo` development server on a local machine.
 
 ```bash


### PR DESCRIPTION
Include instructions for installing Hugo on macOS using Homebrew Bundle and create a Brewfile for managing dependencies.