### PR TITLE
Add parts 2 to 4 of the metadata series

### DIFF
--- a/content/blog/metadata/_index.md
+++ b/content/blog/metadata/_index.md
@@ -37,7 +37,7 @@ Across the series, the focus stays on implementation details rather than governa
 | Part | Title                                                                 | Core Boundary                                     |
 | ---- | --------------------------------------------------------------------- | ------------------------------------------------- |
 | 1    | [Metadata Starts as Column Names](/blog/metadata/part1-field-schema/) | Dataset schema and field semantics                |
-| 2    | Types Become Contracts                                                | Compatibility between producers and consumers     |
+| 2    | [Types Become Contracts](/blog/metadata/part2-schema-contracts/)      | Compatibility between producers and consumers     |
 | 3    | Parquet and the Rise of Physical Metadata                             | File-level performance metadata                   |
 | 4    | Metadata at Lakehouse Scale                                           | Dataset coordination across many files            |
 | 5    | Metadata as Query Planning                                            | Statistics, catalogs, and execution decisions     |
@@ -67,7 +67,7 @@ Expected themes:
 
 ### 2. Types Become Contracts
 
-Once multiple systems exchange structured data, metadata becomes operational. This article will focus on schema evolution, compatibility rules, data contracts, and the differences between formats such as Avro, JSON Schema, and Protobuf.
+Now published as [Types Become Contracts](/blog/metadata/part2-schema-contracts/), this article examines schema evolution, compatibility rules, data contracts, and the differences between formats such as Avro, JSON Schema, and Protobuf.
 
 Expected themes:
 

--- a/content/blog/metadata/_index.md
+++ b/content/blog/metadata/_index.md
@@ -34,15 +34,15 @@ Across the series, the focus stays on implementation details rather than governa
 
 ## Reading Order
 
-| Part | Title                                                                 | Core Boundary                                     |
-| ---- | --------------------------------------------------------------------- | ------------------------------------------------- |
-| 1    | [Metadata Starts as Column Names](/blog/metadata/part1-field-schema/) | Dataset schema and field semantics                |
-| 2    | [Types Become Contracts](/blog/metadata/part2-schema-contracts/)      | Compatibility between producers and consumers     |
-| 3    | Parquet and the Rise of Physical Metadata                             | File-level performance metadata                   |
-| 4    | Metadata at Lakehouse Scale                                           | Dataset coordination across many files            |
-| 5    | Metadata as Query Planning                                            | Statistics, catalogs, and execution decisions     |
-| 6    | AI Systems Need Semantic Metadata                                     | Features, embeddings, chunks, and retrieval       |
-| 7    | Metadata as the Control Plane                                         | Orchestration, governance, and autonomous systems |
+| Part | Title                                                                                        | Core Boundary                                     |
+| ---- | -------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| 1    | [Metadata Starts as Column Names](/blog/metadata/part1-field-schema/)                        | Dataset schema and field semantics                |
+| 2    | [Types Become Contracts](/blog/metadata/part2-schema-contracts/)                             | Compatibility between producers and consumers     |
+| 3    | [Parquet and the Rise of Physical Metadata](/blog/metadata/part3-parquet-physical-metadata/) | File-level performance metadata                   |
+| 4    | Metadata at Lakehouse Scale                                                                  | Dataset coordination across many files            |
+| 5    | Metadata as Query Planning                                                                   | Statistics, catalogs, and execution decisions     |
+| 6    | AI Systems Need Semantic Metadata                                                            | Features, embeddings, chunks, and retrieval       |
+| 7    | Metadata as the Control Plane                                                                | Orchestration, governance, and autonomous systems |
 
 ## Why The Series Is Structured This Way
 
@@ -78,7 +78,7 @@ Expected themes:
 
 ### 3. Parquet and the Rise of Physical Metadata
 
-This article moves from logical schema to physical layout. Parquet footers, row groups, column chunks, encodings, compression metadata, and statistics all shape runtime behavior.
+Now published as [Parquet and the Rise of Physical Metadata](/blog/metadata/part3-parquet-physical-metadata/), this article moves from logical schema to physical layout. Parquet footers, row groups, column chunks, encodings, compression metadata, and statistics all shape runtime behavior.
 
 Expected themes:
 

--- a/content/blog/metadata/_index.md
+++ b/content/blog/metadata/_index.md
@@ -39,7 +39,7 @@ Across the series, the focus stays on implementation details rather than governa
 | 1    | [Metadata Starts as Column Names](/blog/metadata/part1-field-schema/)                        | Dataset schema and field semantics                |
 | 2    | [Types Become Contracts](/blog/metadata/part2-schema-contracts/)                             | Compatibility between producers and consumers     |
 | 3    | [Parquet and the Rise of Physical Metadata](/blog/metadata/part3-parquet-physical-metadata/) | File-level performance metadata                   |
-| 4    | Metadata at Lakehouse Scale                                                                  | Dataset coordination across many files            |
+| 4    | [Metadata at Lakehouse Scale](/blog/metadata/part4-lakehouse-metadata/)                      | Dataset coordination across many files            |
 | 5    | Metadata as Query Planning                                                                   | Statistics, catalogs, and execution decisions     |
 | 6    | AI Systems Need Semantic Metadata                                                            | Features, embeddings, chunks, and retrieval       |
 | 7    | Metadata as the Control Plane                                                                | Orchestration, governance, and autonomous systems |
@@ -89,7 +89,7 @@ Expected themes:
 
 ### 4. Metadata at Lakehouse Scale
 
-At lakehouse scale, metadata is no longer attached to a single file. It becomes a distributed layer spanning manifests, snapshots, partition specs, catalogs, and transaction logs.
+Now published as [Metadata at Lakehouse Scale](/blog/metadata/part4-lakehouse-metadata/), this article explains why table state in object storage cannot be managed as a loose directory of Parquet files once concurrency, rewrites, and many query engines are involved.
 
 Expected themes:
 

--- a/content/blog/metadata/part2-schema-contracts/index.md
+++ b/content/blog/metadata/part2-schema-contracts/index.md
@@ -1,0 +1,323 @@
+---
+title: "Types Become Contracts"
+date: "2026-05-20T10:00:00+09:00"
+tags: ["Metadata", "Data", "Schema", "Architecture"]
+categories: ["Technology", "Data"]
+draft: false
+---
+
+Part 1 ended at an important boundary. Once field meaning becomes explicit, ambiguity drops, but coordination work does not.
+
+A team can document that `customer_id` is a string, `created_at` is UTC, and `plan` belongs to a small enum. That already improves validation and interpretation. The harder problem begins when several producers and consumers depend on the same shape at the same time. A field definition is no longer only descriptive. It starts constraining change.
+
+That is the moment when types become contracts.
+
+This article extends [Metadata Starts as Column Names](/blog/metadata/part1-field-schema/) and the series overview in [Metadata Systems - From Column Comments to Distributed Control Planes](/blog/metadata/). The focus here is narrower than governance language usually implies. The practical question is not whether contracts are a good idea in the abstract. It is how schema changes behave once streams, services, warehouses, and jobs are all relying on them.
+
+## A Schema Becomes A Contract When Change Has Consequences
+
+Inside one script, a type annotation is mostly local. If you rename a field, you update the same codebase and move on.
+
+Across systems, the same change is different. A producer may publish an event to Kafka, a stream processor may transform it, a storage job may land it in object storage, and several consumers may materialize views or trigger workflows from the same topic. None of those systems deploy in lockstep.
+
+Suppose an order service publishes this event:
+
+```json
+{
+  "order_id": "o-1001",
+  "customer_id": "c-42",
+  "status": "paid",
+  "amount_jpy": 12000,
+  "created_at": "2026-05-20T08:15:00Z"
+}
+```
+
+That payload carries more than data values.
+
+- Consumers assume `order_id` is stable.
+- Billing systems assume `amount_jpy` is an integer in yen, not a decimal in major currency units.
+- Status handling code assumes values such as `paid` and `cancelled` have specific business meaning.
+- Monitoring and alerting logic assumes `created_at` is event time, not processing time.
+
+Once those assumptions are encoded in multiple places, the schema has become an interface between independently changing systems. Any modification has to answer a concrete operational question: what happens to consumers that have not changed yet?
+
+That is what a contract protects. It does not guarantee that the business meaning is correct. It guarantees that producers and consumers can coordinate change without relying on simultaneous deployment.
+
+## Compatibility
+
+Most schema discussions eventually reduce to compatibility rules because those rules determine whether a changed producer can safely talk to an unchanged consumer, or vice versa.
+
+The three common terms are backward compatibility, forward compatibility, and full compatibility. They sound simple, but they are only useful when grounded in an actual producer-consumer relationship.
+
+### Backward
+
+Backward compatibility means new consumers can read data produced with an older schema.
+
+Start with a simple Avro-style record:
+
+```avdl
+record OrderCreated {
+  string order_id;
+  string customer_id;
+  int amount_jpy;
+}
+```
+
+Now imagine adding an optional field with a default:
+
+```avdl
+record OrderCreated {
+  string order_id;
+  string customer_id;
+  int amount_jpy;
+  union { null, string } coupon_code = null;
+}
+```
+
+This is typically backward compatible. A new consumer that expects `coupon_code` can still read older messages because the missing field resolves to its default.
+
+An incompatible example is changing the type of `amount_jpy` from `int` to `string` without a migration boundary. Old data remains encoded as numbers. A new consumer expecting strings can no longer interpret the field consistently.
+
+### Forward
+
+Forward compatibility means old consumers can read data produced with a newer schema.
+
+Using the same example, an old consumer that knows only `order_id`, `customer_id`, and `amount_jpy` can usually ignore the newly added `coupon_code` field. That change is often forward compatible.
+
+Renaming a field is usually not. If the producer changes `amount_jpy` to `amount_minor` and the old consumer still expects `amount_jpy`, there is no automatic bridge unless the format or tooling supports aliases and every relevant component uses them correctly.
+
+### Full
+
+Full compatibility requires both directions to remain safe across adjacent versions. In practice, it favors changes that are additive, defaulted, or explicitly aliased rather than destructive.
+
+The safe-looking part matters. A field rename often looks harmless to a human reviewer because the values did not change. For distributed systems, rename is not cosmetic. It changes how the field is located and decoded.
+
+The reason compatibility matters so much is deployment reality. Producers and consumers change at different times. A compatibility rule is a way to survive that gap.
+
+## Change Patterns
+
+Teams often learn compatibility rules as a checklist, but the rules express asymmetry in how systems evolve.
+
+These changes are usually compatible when handled carefully:
+
+- adding an optional field
+- adding a field with a default value
+- expanding a message with data that older consumers can ignore
+- widening certain numeric types when the format supports it and the consumer logic can still interpret the values
+
+These changes are commonly incompatible:
+
+- renaming a field without alias support and migration handling
+- changing a required field to a different logical type
+- making an optional field required without a backfill plan
+- reusing an enum value name for a different semantic meaning
+- changing units without changing the field name and contract description
+
+That last case is where purely syntactic compatibility becomes misleading. If `latency` used to be milliseconds and is now seconds, the schema may still parse. The contract has still been broken.
+
+## Format Tradeoffs
+
+[Avro](https://avro.apache.org/), [JSON Schema](https://json-schema.org/), and [Protobuf](https://protobuf.dev/) are often discussed together because all three describe structure. Operationally, they make different tradeoffs around typing, encoding, and evolution.
+
+### Avro
+
+Avro is strongly oriented toward data pipelines and event streams. Schema is central, and compatibility rules are explicit enough that registries can enforce them in a predictable way.
+
+Avro records are field-based rather than tag-based. That makes names and defaults important to schema evolution.
+
+```json
+{
+  "type": "record",
+  "name": "OrderCreated",
+  "fields": [
+    { "name": "order_id", "type": "string" },
+    { "name": "customer_id", "type": "string" },
+    { "name": "amount_jpy", "type": "int" },
+    {
+      "name": "coupon_code",
+      "type": ["null", "string"],
+      "default": null
+    }
+  ]
+}
+```
+
+Operational strengths:
+
+- clear defaults and unions support additive evolution
+- registry tooling commonly supports backward and forward checks
+- compact binary encoding works well in streaming systems
+
+Operational limits:
+
+- schema design discipline matters because field names and defaults carry a lot of migration weight
+- certain changes that look small, such as renames, require deliberate handling rather than casual refactors
+
+### JSON Schema
+
+JSON Schema is flexible and widely used for APIs and validation boundaries. It is excellent at expressing constraints, but that same flexibility makes evolution rules less uniform across tooling.
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "order_id": { "type": "string" },
+    "customer_id": { "type": "string" },
+    "amount_jpy": { "type": "integer", "minimum": 0 },
+    "coupon_code": { "type": ["string", "null"] }
+  },
+  "required": ["order_id", "customer_id", "amount_jpy"],
+  "additionalProperties": false
+}
+```
+
+Operational strengths:
+
+- expressive validation rules for objects, patterns, ranges, and nested structures
+- natural fit for HTTP payload validation and JSON-native systems
+- easy for humans to inspect and reason about
+
+Operational limits:
+
+- compatibility policy is less intrinsic than in Avro; teams must define what counts as safe
+- permissiveness varies with schema style, especially around `additionalProperties`, defaults, and loose typing
+- binary transport and compact evolution are not the primary design center
+
+JSON Schema is best understood as a strong validation language, not as a single standardized evolution strategy.
+
+### Protobuf
+
+Protobuf is optimized for service communication and binary efficiency. Evolution works differently because fields are identified by numeric tags, not only names.
+
+```proto
+syntax = "proto3";
+
+message OrderCreated {
+  string order_id = 1;
+  string customer_id = 2;
+  int32 amount_jpy = 3;
+  string coupon_code = 4;
+}
+```
+
+Operational strengths:
+
+- compact binary encoding and generated clients work well for service boundaries
+- unknown fields can be ignored by older readers in many scenarios
+- numeric tags provide a stable identity even if display names change
+
+Operational limits:
+
+- tag reuse is dangerous; once a field number is published, it effectively becomes part of the long-term contract
+- presence, defaults, and optional semantics can be subtle depending on version and language runtime
+- service teams may mistake syntactic success for semantic safety because decoding still works after a meaning change
+
+Protobuf tends to make safe additive evolution straightforward, but it punishes careless field retirement and tag recycling.
+
+## Schema Registries
+
+Once events move through a shared stream, compatibility rules need somewhere to live. This is why schema registries matter.
+
+Consider a Kafka topic called `orders.created`. A producer service writes messages, a fraud service consumes them in real time, a storage sink lands them into object storage, and an analytics pipeline reads the stored data later. Without a registry, each component may carry its own copy of the schema, its own parsing assumptions, and its own release timing.
+
+A registry centralizes several operational functions:
+
+- schema version storage
+- compatibility validation at registration time
+- schema lookup by identifier during serialization and deserialization
+- shared visibility into which subject or topic uses which contract
+
+In practice, teams rarely implement this layer from scratch. They usually adopt registry tooling that is already integrated with their event platform, serializer stack, or cloud environment. Common examples include [Confluent Schema Registry](https://docs.confluent.io/platform/current/schema-registry/index.html), which is closely associated with Kafka and Avro-centric workflows, [Apicurio Registry](https://www.apicur.io/registry/), which supports multiple schema and API artifact types in a more general registry model, [Karapace](https://karapace.io/), which provides a Schema Registry-compatible option commonly used in Kafka deployments, and [AWS Glue Schema Registry](https://docs.aws.amazon.com/glue/latest/dg/schema-registry.html), which targets managed streaming and event-driven integration inside AWS environments.
+
+Those tools differ in packaging, ecosystem assumptions, and supported artifact models, but they solve the same operational problem: making schema compatibility checks happen before bad messages spread through a running system.
+
+The important effect is not centralization for its own sake. It is the ability to reject a bad change before it hits a hot path.
+
+For example, if the current schema for `orders.created` requires `amount_jpy` and a producer attempts to register a new version that renames it to `amount_minor` without an allowed compatibility path, the registry can fail the registration. That failure is cheap compared with discovering the problem through broken consumers after deployment.
+
+In streaming systems, that difference matters because messages are not polite. Once published, they propagate quickly into state stores, compacted topics, dead-letter queues, and long-retained storage. Rejecting an incompatible schema up front is often the lowest-cost control point.
+
+Registries also make contract scope visible. A schema attached to one internal topic is not the same as a schema attached to a public event stream consumed by many teams. The compatibility setting may need to be stricter for the latter because deployment coordination is weaker.
+
+## Migration Failures
+
+Initial schemas are rarely perfect, but most production pain comes from how they change.
+
+### Field Renames
+
+Field rename is one of the most common mistakes because it looks harmless in source control.
+
+From the producer perspective, changing `customer_id` to `account_id` might reflect a better domain model. For existing consumers, it removes the field they depend on and introduces one they do not recognize. Unless the migration keeps both names temporarily, or the format supports aliases in a way every consumer actually uses, this is a breaking change.
+
+### Enum Expansion
+
+Adding enum values looks additive, but downstream logic often treats enum domains as closed.
+
+Suppose an order status enum originally contains `pending`, `paid`, and `cancelled`. A producer later adds `refunded`.
+
+```proto
+enum OrderStatus {
+  ORDER_STATUS_UNSPECIFIED = 0;
+  PENDING = 1;
+  PAID = 2;
+  CANCELLED = 3;
+  REFUNDED = 4;
+}
+```
+
+Parsing may still succeed. Consumer business logic may not. Dashboards can drop the new state. Alerting rules can misclassify it. State machines can fall into default branches that were never meant for valid production traffic.
+
+This is a good example of the difference between wire compatibility and behavioral compatibility.
+
+### Requiredness Changes
+
+Changing a field from optional to required is often a contract violation disguised as cleanup.
+
+If older producers omit `coupon_code`, a new consumer that now requires it cannot safely process historical messages or lagging producers. Even in request-response systems, rolling deployments mean some nodes will still send the older shape for a while.
+
+The safe path is usually staged:
+
+1. Add the field as optional.
+2. Backfill or populate it consistently.
+3. Verify population across producers.
+4. Only then consider tightening validation where every participant can meet the stronger requirement.
+
+### Semantic Drift
+
+Semantic drift is the most expensive failure mode because schema validators cannot fully catch it.
+
+Imagine that `amount_jpy` initially means gross order amount including tax. Later, the producer changes it to net amount before tax to satisfy a new finance process, but keeps the field name unchanged to avoid breaking parsers.
+
+Everything still deserializes. Nothing is syntactically broken. Revenue dashboards, fraud thresholds, refund logic, and anomaly detection all start operating on a different meaning.
+
+This is why contracts cannot stop at type-level compatibility. A field name, description, unit, and business definition are all part of what consumers rely on.
+
+## Semantic Compatibility
+
+Schema tooling is good at checking structure. It is weaker at checking meaning.
+
+Two payloads can be structurally compatible while being operationally incompatible:
+
+- currency changes from yen to dollars while the integer type stays the same
+- `created_at` changes from event time to ingestion time while remaining a timestamp
+- `customer_id` changes from a global identifier to a tenant-local identifier while staying a string
+
+These failures often arrive during migrations because teams focus on parser success. Parser success is a necessary condition, not a sufficient one.
+
+A practical contract therefore needs both machine-checkable structure and human-maintained semantic guarantees. That usually means keeping descriptions, units, ownership, and migration notes close to the schema rather than in disconnected prose. It also means reviewing changes with consumer behavior in mind, not only serializer behavior.
+
+One useful question in review is simple: if an unchanged consumer silently accepts this new message, could it still produce the wrong answer? If the answer is yes, the change may be syntactically compatible but semantically unsafe.
+
+## Beyond Contracts
+
+At this stage, metadata is already operational.
+
+It controls whether events can be published, whether consumers can decode them, whether validators reject bad payloads, and whether rolling deployments remain safe. That is a major shift from the Part 1 world of column names and field descriptions.
+
+It is still not the whole system.
+
+Contracts protect logical interpretation across producers and consumers. They do not explain how metadata affects scan cost, predicate pruning, encoding choices, row-group layout, or file-level planning once data lands in large analytical storage formats. A stream contract can tell a consumer that `created_at` is a timestamp. It cannot tell a query engine how many row groups can be skipped before reading a Parquet file.
+
+That next step matters because metadata eventually stops being only an interface between applications. It becomes part of compute efficiency itself.
+
+Part 3 moves into that boundary. Once data is stored in large columnar files, metadata is no longer only a logical contract between producer and consumer. It starts controlling what work the engine has to do.

--- a/content/blog/metadata/part3-parquet-physical-metadata/index.md
+++ b/content/blog/metadata/part3-parquet-physical-metadata/index.md
@@ -1,0 +1,280 @@
+---
+title: "Parquet and the Rise of Physical Metadata"
+date: "2026-05-21T10:00:00+09:00"
+tags: ["Metadata", "Data", "Schema", "Architecture"]
+categories: ["Technology", "Data"]
+draft: false
+---
+
+Part 2 ended at the boundary where schema becomes operational. Once producers and consumers depend on the same structure, metadata is no longer just descriptive. It constrains change.
+
+Large-scale analytical storage adds a different requirement. Correctness is not enough. Engines also need metadata that helps them avoid unnecessary work.
+
+That is where physical metadata enters the picture.
+
+This article extends [Types Become Contracts](/blog/metadata/part2-schema-contracts/) and the series overview in [Metadata Systems - From Column Comments to Distributed Control Planes](/blog/metadata/). The focus here is not Parquet as a brand name or a generic introduction to columnar formats. The practical question is how metadata embedded in a file influences scan cost, pruning, interoperability, and execution shape before most data bytes are even decoded.
+
+## Storage Needs More Than Correctness Metadata
+
+A schema contract can tell a consumer that `created_at` is a timestamp and `country_code` is a two-letter string. That matters for interpretation and compatibility. It does not tell a query engine whether 98 percent of a file can be skipped for a date filter.
+
+That difference is the step from logical metadata to physical metadata.
+
+Logical metadata answers questions such as these:
+
+- What fields exist?
+- What type does each field have?
+- Which fields are required or optional?
+- What meaning or compatibility guarantees do downstream systems rely on?
+
+Physical metadata answers different questions:
+
+- Where in the file is each column stored?
+- How many row groups exist?
+- What encoding and compression were used?
+- What are the min and max values for a column segment?
+- Can a filter eliminate a row group before any data pages are read?
+
+CSV and JSON sharpen the contrast. They can describe records, but they give the engine very little structural help once bytes hit storage. A CSV reader typically has to scan linearly, tokenize rows, and interpret values after the fact. JSON adds nested structure but still offers no compact footer that says where a column lives, what its page boundaries are, or whether a whole segment can be skipped for `event_date >= '2026-05-01'`.
+
+[Parquet](https://parquet.apache.org/) was built for that missing layer. It stores data in a columnar layout and pairs the encoded column data with metadata that query engines can inspect quickly. The file does not only hold values. It also carries a plan for how those values can be found, skipped, and decoded.
+
+## File Layout
+
+Parquet file structure is easiest to understand from the end of the file backward.
+
+The important metadata lives in the footer. A reader usually performs a small ranged read near the end of the object, discovers the footer length, and then reads the serialized metadata block. That block contains the schema, row-group inventory, per-column chunk metadata, encodings, compression information, offsets, and statistics.
+
+A compact mental model looks like this:
+
+```text
+PAR1
+  column data pages
+  column data pages
+  ...
+  row group N column chunks
+  serialized footer metadata
+footer_length
+PAR1
+```
+
+The exact wire format is more detailed, but operationally the footer gives the engine an index into the file.
+
+The main structural units are these:
+
+- Row group: a horizontal partition of rows inside one file
+- Column chunk: the bytes for one column within one row group
+- Page: a smaller unit inside a column chunk, used for data and dictionary storage
+- Footer metadata: the file-level directory that describes how all of those pieces fit together
+
+In practice, the footer usually contains at least four categories of information that matter to readers:
+
+- schema metadata for the file
+- per-row-group row counts and byte sizes
+- per-column-chunk offsets, encodings, codecs, and statistics
+- enough structural detail to let the engine plan ranged reads instead of blind full-file scans
+
+That last point is easy to underestimate. In object storage environments, a reader often does not want to download the entire file just to discover whether the query needs 3 percent of it or 90 percent of it. The footer makes a cheap planning phase possible. The engine can issue a small read near the file tail, decode metadata, and then request only the byte ranges that correspond to the selected column chunks. That design fits modern analytical storage well because file metadata can be inspected with far less network and CPU cost than full decoding.
+
+Suppose a file contains columns `order_id`, `customer_id`, `created_at`, `country_code`, and `amount_jpy` for 10 million rows. A writer may divide those rows into five row groups of 2 million rows each. Inside each row group, every column is written separately as its own column chunk. The footer records where each chunk starts, how large it is, what codec was used, and what statistics were collected.
+
+That structure is why Parquet readers do not behave like line-oriented readers. They can decide to read only the `created_at` and `amount_jpy` chunks for a query that never touches `customer_id`. They can also inspect statistics first and conclude that some row groups cannot possibly match the predicate.
+
+Pages make the structure more granular still. A column chunk is not a single undifferentiated blob. It is a sequence of pages, often including an optional dictionary page followed by data pages. That gives writers and readers a useful tradeoff boundary. The footer gets the engine to the right chunk. Page structure governs how values are actually decoded inside that chunk. The distinction matters because Parquet metadata works at several layers at once: file planning, row-group pruning, column projection, and page-level decoding.
+
+## Pruning
+
+The most immediately valuable Parquet metadata is statistics.
+
+At row-group or page scope, writers may record values such as:
+
+- minimum value
+- maximum value
+- null count
+- distinct count in some implementations or adjacent systems
+
+Consider a file with three row groups for `event_date`:
+
+```text
+row group 1: min=2026-05-01, max=2026-05-07
+row group 2: min=2026-05-08, max=2026-05-14
+row group 3: min=2026-05-15, max=2026-05-21
+```
+
+Now run this filter:
+
+```sql
+SELECT count(*)
+FROM events
+WHERE event_date >= DATE '2026-05-15';
+```
+
+An engine can inspect footer metadata before reading most column data. Row groups 1 and 2 cannot satisfy the predicate, so they are eliminated. Only row group 3 needs to be scanned.
+
+The same pattern applies to numeric ranges:
+
+```text
+column: amount_jpy
+row group 1: min=100, max=1200
+row group 2: min=1300, max=4500
+row group 3: min=5000, max=25000
+```
+
+For `WHERE amount_jpy > 10000`, the first two groups can be skipped immediately.
+
+This is often described as predicate pushdown, but the useful detail is where the decision happens. The engine is not pushing a predicate into a remote database server. It is using file metadata to decide which physical segments are worth reading.
+
+Null counts matter too. If a query asks for `WHERE coupon_code IS NOT NULL` and a row group has a null count equal to the row-group row count, that segment contributes nothing and can be skipped.
+
+Partition directories often work alongside Parquet metadata, not instead of it. A dataset might be physically laid out under object storage paths such as:
+
+```text
+s3://warehouse/events/dt=2026-05-21/part-0001.parquet
+```
+
+Directory partitioning can prune whole files from a path filter. Footer statistics then prune further within the surviving files. One is dataset-adjacent metadata. The other is file-embedded metadata. Real engines commonly use both.
+
+The quality of pruning depends on how files were written. If rows are appended in arbitrary order, min and max ranges may overlap heavily and every row group looks potentially relevant. If data is clustered by a frequently filtered column such as date, tenant, or region, the statistics become far more selective. Parquet does not create that value automatically. Writers and table-maintenance workflows have to preserve some amount of locality for the metadata to stay informative.
+
+## Types
+
+Parquet's type system is another place where metadata stops being decorative.
+
+The format distinguishes between physical types and logical types. Physical types describe how values are actually stored. Logical types describe the higher-level meaning a reader should reconstruct.
+
+For example:
+
+- `INT32` may physically store a date as days since the Unix epoch
+- `BYTE_ARRAY` may physically store UTF-8 strings
+- `INT64` may physically store timestamps with a particular unit
+- `FIXED_LEN_BYTE_ARRAY` may physically store decimal values
+
+One concrete mapping is a decimal amount:
+
+```text
+logical type: DECIMAL(12,2)
+physical type: FIXED_LEN_BYTE_ARRAY(8)
+```
+
+Another is a date:
+
+```text
+logical type: DATE
+physical type: INT32
+```
+
+Why does this distinction matter? Because storage efficiency and interoperability pull in different directions.
+
+On the storage side, a small set of physical primitives keeps encoding and vectorized processing practical. On the interoperability side, readers need enough metadata to reconstruct the intended semantics. If a system sees only `INT32`, it cannot know whether the value means a count, a date, or an enum-like code. The logical annotation closes that gap.
+
+This is one reason Parquet metadata matters beyond one engine. A file may be written by Spark, scanned later by DuckDB, read through Arrow libraries, or queried by Trino. Those systems do not share runtime memory structures, but they can converge on the same interpretation if the physical and logical metadata are both preserved clearly enough.
+
+When metadata is ambiguous, portability suffers. Timestamp semantics are a common example. Physical storage alone does not fully answer whether the value should be interpreted as UTC-normalized time, local wall time, or a specific precision boundary. Engines that make slightly different assumptions can all read the file and still disagree subtly about meaning.
+
+## Encodings
+
+Parquet metadata also tells the reader how values were encoded and compressed.
+
+Writers may choose encodings such as dictionary encoding, run-length encoding, or plain encoding depending on data characteristics. Compression codecs such as Snappy, Zstandard, or Gzip may then be applied to column pages.
+
+Those choices directly affect runtime behavior.
+
+Dictionary encoding is a good example. If `country_code` contains a small repeating set of values, storing a compact dictionary plus integer references can shrink storage and improve scan locality. The footer and page metadata tell the reader what encoding is in use so it can decode values correctly and, in some cases, apply filters efficiently against dictionary contents before fully materializing rows.
+
+Compression metadata matters for the same reason. A reader deciding whether to project three columns or thirty is also deciding how many compressed chunks need to be fetched and decompressed. Because Parquet is columnar, compression cost is tied to the selected columns and row groups, not to the entire record structure.
+
+This is one of the reasons CSV and JSON comparisons remain useful. With row-oriented text formats, projection savings are limited because parsing still touches most of the file. With Parquet, column metadata makes selective access a normal execution path rather than a best effort.
+
+## Arrow
+
+Parquet becomes more important when viewed together with [Arrow](https://arrow.apache.org/).
+
+Parquet is a storage format optimized for durable, compact, columnar files. Arrow is an in-memory columnar format optimized for efficient analytical processing and interchange between runtimes. They solve different problems, but they align well because both are built around columnar access and typed arrays.
+
+In a common read path, an engine inspects Parquet metadata, selects the needed row groups and columns, decodes the relevant pages, and materializes them into Arrow-like column vectors or equivalent internal buffers. That handoff is not accidental. Parquet metadata helps the engine avoid decoding data that will never be needed, while Arrow-compatible vector layouts let the engine process the surviving data in batches.
+
+This is where physical metadata becomes execution infrastructure.
+
+If a query touches only `created_at`, `country_code`, and `amount_jpy`, the engine can skip unrelated columns at the file level. If statistics show that only two row groups match the predicate, it can skip the others. The remaining pages are decoded into contiguous vectors that fit vectorized operators such as filter, aggregate, and hash probe more naturally than row-by-row interpretation.
+
+The result is not just lower I/O. It is a different execution shape. Metadata determines what enters the vectorized path at all.
+
+Consider a concrete analytical query:
+
+```sql
+SELECT country_code, sum(amount_jpy)
+FROM orders
+WHERE created_at >= TIMESTAMP '2026-05-01 00:00:00'
+  AND created_at < TIMESTAMP '2026-06-01 00:00:00'
+GROUP BY country_code;
+```
+
+In a reasonably organized Parquet dataset, the engine can often follow a staged decision process:
+
+1. Use partition metadata, if present, to eliminate files outside the month.
+2. Read Parquet footers for the surviving files.
+3. Use row-group statistics on `created_at` to skip groups that fall entirely outside the range.
+4. Project only `created_at`, `country_code`, and `amount_jpy` instead of the full table schema.
+5. Decode the selected pages into column vectors and run filter plus aggregation operators over those vectors.
+
+Most of the important work happens before full value materialization. That is the central systems point. Metadata is not merely helping documentation or interoperability here. It is deciding which bytes become computation at all.
+
+This also clarifies why Parquet metadata is not the same thing as a secondary index in an OLTP system. The engine is still scanning selected file segments, not performing point lookups against a mutable index tree. But for analytical workloads, that combination of projection, pruning, and batched decoding is often exactly the right compromise between write simplicity and read efficiency.
+
+## Tradeoffs
+
+Parquet metadata is powerful, but it is not magical.
+
+The tradeoffs fall into two broad categories. Some are about semantic boundaries: what the file format can describe reliably, and what has to live in higher-level metadata systems. Others are about execution quality: how well the metadata supports pruning, planning, and portable performance.
+
+### Semantic Boundaries
+
+This is also the point where Parquet's limits become visible.
+
+Teams often want a column to carry more than type information. They want a human-readable description such as "gross order amount in yen after discounts" or "customer signup timestamp recorded in Tokyo local time." Those are real metadata needs because they affect interpretation, not just documentation quality.
+
+Parquet can carry some schema meaning, but it is not a general-purpose field documentation format. In the portable core format, a column has a name, physical type information, repetition rules, and optional logical type annotations. What it does not provide as a strong, standard cross-engine feature is a first-class per-column description field equivalent to a database column comment.
+
+That distinction matters operationally. Some engines and libraries can attach custom metadata when writing files, and file-level key-value metadata exists. Certain ecosystems can also preserve richer field annotations through adjacent schema layers, such as an embedded Arrow schema or external table metadata in a catalog or lakehouse format. But those paths are not the same as saying that raw Parquet itself is a reliable, universal home for portable column descriptions.
+
+So if the question is "can Parquet carry the description of a column?" the practical answer is: not in a standard way that every engine will interpret as an official column comment. If a description must survive across tools, review processes, and data products, it is usually safer to keep it in the table schema, catalog, registry, or another metadata layer designed for semantic documentation.
+
+Timezone handling has a similar boundary.
+
+Parquet can represent timestamp intent better than a bare string or integer, but it still does not solve every timezone problem. In modern Parquet logical types, timestamp metadata can express the time unit and whether the value is adjusted to UTC. That helps readers distinguish between an instant-like timestamp and a local timestamp interpretation.
+
+What Parquet does not generally give you is a named timezone such as `Asia/Tokyo` stored as a standard logical-type parameter for the column. In other words, Parquet can help say "this timestamp is normalized to UTC" versus "this timestamp is not adjusted to UTC," but it is not the universal place to encode the business rule that a source system uses Japan Standard Time or America/Los_Angeles for interpretation.
+
+That leaves teams with a practical pattern:
+
+- use Parquet logical timestamp annotations for unit and UTC-adjustment semantics
+- store named timezone rules in adjacent metadata or in the data contract
+- if the source timezone is analytically important per row, store it explicitly as data rather than assuming readers will recover it from file metadata
+
+This is consistent with the broader pattern in the series. Physical metadata is excellent at helping engines find, prune, and decode data. It is weaker as a complete carrier of business semantics. Once teams need rich descriptions, ownership context, units, or explicit timezone conventions, they usually have to combine Parquet with higher-level metadata systems rather than relying on the file format alone.
+
+### Execution Quality
+
+The first operational tradeoff is statistics quality. Pruning works only if the collected metadata is present and useful. If writers omit statistics, truncate them, or generate row groups that mix values too broadly, filters become less selective. A file can still be valid Parquet while being a poor pruning target.
+
+The second tradeoff is file and row-group sizing. Very small files increase planning overhead and object-store request cost. Very large row groups can weaken selectivity and force heavier reads for targeted predicates. There is no single perfect size because the right choice depends on workload shape, object storage behavior, and downstream engine expectations.
+
+The third tradeoff is portability versus engine-specific optimization. Parquet is intentionally interoperable, but not every optimization is equally portable. Some engines rely heavily on certain statistics, page indexes, or writer behaviors. Others are more conservative. A dataset tuned for one engine can remain readable everywhere while delivering uneven performance elsewhere.
+
+There is also a semantic risk hidden inside physically valid storage. A column can be well-encoded and richly annotated yet still change meaning in ways that confuse downstream readers. Logical metadata helps, but it does not eliminate governance or migration discipline. Physical efficiency does not replace semantic correctness.
+
+There is also a subtle failure mode around stale assumptions. Engineers often treat Parquet as inherently fast, then stop inspecting how files are actually written. But scan behavior is a property of the concrete metadata in the produced files, not the file extension alone. Bad sorting, broad row-group ranges, inconsistent logical annotations, or unnecessary column duplication can all erode the benefits people assume they are getting.
+
+## Beyond One File
+
+At this point, metadata is doing more than describing fields.
+
+The footer tells readers how a file is organized. Row-group and column-chunk statistics decide whether segments can be skipped. Type annotations preserve meaning across engines. Encoding and compression metadata shape the cost of decoding. Arrow-aligned read paths turn those decisions into vectorized execution.
+
+That is a major shift from Part 2. There, metadata coordinated producers and consumers around correctness. Here, metadata also controls how much compute is required to answer a query.
+
+But Parquet still keeps the metadata scope bounded to a file and to nearby storage layout such as partition directories. Once a dataset spans thousands of files, the next problem appears. Engines need metadata that can reason across file sets, snapshots, partition evolution, and concurrent change.
+
+That is the handoff to Part 4.
+
+Once metadata lives across many files, manifests, and snapshots, it stops being only a file index. It becomes a distributed coordination layer for the dataset itself.

--- a/content/blog/metadata/part4-lakehouse-metadata/index.md
+++ b/content/blog/metadata/part4-lakehouse-metadata/index.md
@@ -1,0 +1,261 @@
+---
+title: "Metadata at Lakehouse Scale"
+date: "2026-05-21T12:00:00+09:00"
+tags: ["Metadata", "Data", "Architecture", "Lakehouse"]
+categories: ["Technology", "Data"]
+draft: false
+---
+
+Part 3 ended at the point where metadata outgrew a single file.
+
+A Parquet footer can tell a reader how one object is laid out, what statistics exist for its row groups, and which column chunks are worth reading. That is powerful, but only within the boundary of that file. Modern analytical datasets are rarely one file. They are usually thousands of Parquet objects in object storage, written over time by independent jobs, queried by multiple engines, and updated under real concurrency.
+
+That is where metadata becomes a dataset-wide coordination layer.
+
+This article extends [Parquet and the Rise of Physical Metadata](/blog/metadata/part3-parquet-physical-metadata/) and the series overview in [Metadata Systems - From Column Comments to Distributed Control Planes](/blog/metadata/). The practical question is not how one file can be scanned efficiently. It is how a table spread across many files can change safely while still giving engines a stable, efficient view of the data.
+
+## File Metadata Is Not Table Metadata
+
+Part 3 focused on file metadata.
+
+File metadata answers questions such as these:
+
+- What schema is embedded in this file?
+- What row groups and column chunks exist?
+- What min and max statistics are available?
+- Which byte ranges need to be fetched to decode selected columns?
+
+Those are local questions. They help with scan planning inside one object.
+
+Lakehouse systems need a second layer that answers table questions instead:
+
+- Which files currently belong to the table?
+- Which snapshot of the table should a query read?
+- Which schema and partition spec are current?
+- What changed between two commits?
+- How do two writers avoid publishing conflicting table state?
+
+That distinction matters because object storage does not natively provide table semantics. An object store can keep blobs durably and serve ranged reads well, but it does not tell an engine which 14,000 Parquet files are the consistent current version of `orders`, nor does it provide an atomic table update primitive in the way a traditional database catalog does.
+
+Without a higher metadata layer, engines often fall back to expensive and fragile patterns:
+
+- recursively listing directories to discover files
+- inferring partitions from path names alone
+- assuming that all visible files are part of the latest table state
+- relying on ad hoc conventions to detect in-progress or obsolete writes
+
+Those patterns break down under scale. Listing large prefixes is expensive. Concurrent writers can race. Partial rewrites can expose mixed table state. Schema changes become hard to reason about because there is no authoritative versioned table definition.
+
+Open table formats such as [Apache Iceberg](https://iceberg.apache.org/) and [Delta Lake](https://delta.io/) exist to solve that coordination problem. They treat the table as a versioned metadata structure whose state points to data files, rather than treating a directory full of files as the table itself.
+
+## Object Storage Changes The Coordination Problem
+
+It is useful to separate why Parquet became popular from why lakehouse metadata became necessary.
+
+Parquet solved efficient file layout for analytical scans. Object storage solved cheap, durable, scalable storage. Neither by itself solved table coordination.
+
+Suppose a daily append pipeline writes these objects:
+
+```text
+s3://warehouse/orders/dt=2026-05-19/part-0001.parquet
+s3://warehouse/orders/dt=2026-05-19/part-0002.parquet
+s3://warehouse/orders/dt=2026-05-20/part-0001.parquet
+...
+```
+
+If the table is append-only and a single engine reads it casually, directory discovery may appear acceptable for a while.
+
+Pressure arrives from four directions.
+
+First, file counts grow. A query should not have to list and inspect every object under a large prefix just to discover which files are live.
+
+Second, updates and deletes appear. Analytical tables are no longer only append logs. Teams rewrite partitions, compact files, apply GDPR deletes, merge CDC streams, and backfill historical slices.
+
+Third, many engines read the same table. Spark, Trino, Flink, DuckDB, and custom services need a shared definition of current table state even though they do not share runtime memory.
+
+Fourth, multiple writers show up. A batch compaction job, a streaming ingest job, and a backfill process may all try to publish changes around the same time.
+
+At that point, the real problem is not file encoding. It is distributed coordination over table state.
+
+The lakehouse answer is to make metadata authoritative. Queries resolve a table version first, then derive the relevant file set from that version. Compute follows metadata, not the other way around.
+
+## Iceberg
+
+[Apache Iceberg](https://iceberg.apache.org/) models a table as a hierarchy of metadata files, snapshots, manifest lists, and manifests.
+
+The important idea is not the exact serialization format. It is the separation of concerns.
+
+- Table metadata files describe table-level state such as the current snapshot, schema versions, partition specs, sort orders, and table properties.
+- A snapshot represents one committed version of the table.
+- A manifest list records which manifests belong to that snapshot.
+- Each manifest records a set of data files and metadata about those files, such as partition values, statistics, sequence numbers, and status.
+
+That structure gives Iceberg a scalable answer to a simple question: which files are in the table right now?
+
+The answer is not "whatever files are present under this directory." It is "the files reachable from the current snapshot through its manifest list and manifests."
+
+### Flow
+
+A simplified Iceberg read flow looks like this in prose.
+
+1. The engine asks a catalog for the current table metadata location.
+2. It reads the current table metadata file and learns the active snapshot ID.
+3. It loads the manifest list for that snapshot.
+4. It reads only the manifests that may satisfy the query predicate.
+5. From those manifests, it derives the exact data files that must be scanned.
+6. Only then does it begin planning Parquet or ORC reads against the selected files.
+
+That is already a major improvement over directory listing. The engine does not need to recursively crawl object storage to reconstruct table membership. It reads a compact metadata path that already describes the table version.
+
+Manifests also reduce coordination cost at query time. Instead of opening every file footer in a large dataset just to decide relevance, the engine can often use manifest-level partition information and file statistics first. If a query filters on `event_date = '2026-05-20'`, a large fraction of manifests and data files can be eliminated before any Parquet footer reads occur.
+
+This is the key distinction:
+
+- Parquet metadata helps prune within a file.
+- Iceberg metadata helps prune across the table before many files are touched at all.
+
+### Snapshots
+
+Snapshots are the unit of consistent table state.
+
+When a writer appends new data, rewrites a set of files, or applies a delete, it does not mutate the visible table in place one file at a time. It prepares new metadata that describes the next snapshot, then commits that snapshot atomically through the catalog mechanism.
+
+That gives readers a stable view. A query starting on snapshot `N` keeps reading that snapshot even if snapshot `N+1` is committed a moment later. This is one reason lakehouse tables can offer repeatable analytical reads without relying on database page latches or storage-engine internals.
+
+Snapshots also make table history explicit. Engines and operators can ask questions such as these:
+
+- What files were added by the last commit?
+- Which snapshot introduced a schema change?
+- Can a table be rolled back to an earlier consistent state?
+
+Those are metadata questions, not file-format questions.
+
+## Delta Lake
+
+[Delta Lake](https://delta.io/) reaches a similar goal through a different metadata model centered on a transaction log.
+
+Instead of representing table state primarily through manifest trees, Delta records table changes as an ordered log under `_delta_log`. JSON commit files and periodic checkpoints capture actions such as adding files, removing files, updating table metadata, and changing protocol versions.
+
+Conceptually, the current table state is derived by replaying the log up to a version, then consulting checkpoints so engines do not need to reprocess the entire history every time.
+
+The central idea is straightforward: the table is defined by an ordered history of metadata actions, not by the raw directory contents.
+
+### Commit Example
+
+A simplified append in Delta can be pictured like this.
+
+The writer produces new Parquet data files first. It does not make them visible as table state merely by uploading them.
+
+Then it attempts to commit a new log version containing actions similar to these:
+
+```json
+{
+  "add": {
+    "path": "part-00017-...snappy.parquet",
+    "partitionValues": { "dt": "2026-05-20" },
+    "size": 13428192,
+    "stats": "{\"numRecords\":500000,\"minValues\":{...},\"maxValues\":{...}}"
+  }
+}
+```
+
+If that commit succeeds, the file becomes part of the next table version. If it fails due to a conflicting concurrent update, the writer must reevaluate against the new latest version.
+
+That is why the log matters. Visibility is controlled by the metadata commit, not by the existence of a Parquet file in storage.
+
+### Concurrency
+
+Delta Lake is commonly described as using optimistic concurrency control. The useful operational meaning is this: writers assume conflicts are relatively infrequent, proceed without holding long exclusive locks over the entire write path, and validate at commit time whether the table changed in a way that invalidates their assumptions.
+
+Consider two jobs:
+
+- Job A compacts yesterday's small files into larger files.
+- Job B appends late-arriving records into the same table.
+
+Both may start from table version 120. If Job A tries to commit version 121 after Job B has already committed a change that overlaps the same logical scope, Job A may need to retry or fail, depending on the conflict semantics.
+
+That pattern is familiar from distributed systems more broadly. The important point is that metadata is where the concurrency check lives. The storage layer is holding immutable data files; the log is coordinating which file set constitutes the table.
+
+Checkpointing exists because log growth would otherwise become its own scaling problem. A mature table may have thousands of commits. Periodic checkpoints materialize table state so new readers can bootstrap from a recent compact representation plus a smaller suffix of log entries.
+
+## Hive Metastore
+
+[Apache Hive](https://hive.apache.org/) and the Hive Metastore remain important reference points because they illustrate what older metadata patterns did well and where they start to strain.
+
+Hive Metastore provided a central catalog for tables, schemas, partitions, and storage locations. That was a major step forward compared with each engine inventing its own unmanaged path conventions.
+
+The limitation is not that Hive Metastore was useless. The limitation is that it was designed around a different pressure profile.
+
+In classic external-table usage, partition directories might be registered in the metastore while the actual file inventory still lives implicitly in storage. Under modern workload pressure, that leaves several gaps:
+
+- the table catalog may know partition paths but not the full authoritative file set for a snapshot
+- updates and deletes often rely on rewriting paths in ways that are not naturally transactional at table scale
+- partition counts can become extremely large and expensive to manage
+- engines may still need heavy listing behavior below each partition
+- schema and partition evolution are more awkward than in newer open table formats
+
+This is why Hive Metastore is best seen here as a contrast case. It centralizes some metadata, but it does not by itself provide the richer snapshot-oriented coordination model that Iceberg and Delta need for modern concurrent lakehouse workloads.
+
+Many production deployments still use a metastore-like service or a modern catalog API as an entry point. The difference is what the catalog points to. In a lakehouse design, the catalog resolves a versioned table metadata structure rather than standing in for the complete coordination logic by itself.
+
+## Evolution
+
+Once metadata becomes the table control plane, evolution rules become explicit operational concerns.
+
+Schema evolution is the most obvious case. Adding a column is not just a parser change. The table metadata must record the new schema version, preserve field identity or evolution semantics correctly, and let readers reconcile old files with new ones.
+
+This is one reason Iceberg's field IDs matter operationally. A rename should not be interpreted as dropping one field and adding a different field when the intent is only to relabel the same logical column. Stable field identity helps engines and maintenance jobs reason about evolution more safely than name matching alone.
+
+Partition evolution is just as important. Real tables outgrow their initial partition design. A dataset that began partitioned by day may later need month-level partitioning, bucket transforms, or hidden partition transforms on timestamp columns.
+
+Older layouts often treat the partition path as the definition. That makes change painful because the storage directory shape becomes part of the contract. Modern table formats decouple the logical partition spec from the raw directory naming enough to let the table evolve while remaining queryable.
+
+Atomic table state changes are the other half of the story.
+
+If a maintenance job rewrites 800 small files into 20 larger files, readers should not observe a half-finished mix where some old files are removed and only some replacements are visible. The whole change needs to appear as one metadata transition from one snapshot or log version to the next.
+
+That is the fundamental distributed-systems move in lakehouse metadata: immutable data files plus atomic publication of table state.
+
+## Operations
+
+The clean metadata models are necessary, but they do not remove operational pressure. They mostly make that pressure legible.
+
+Small files are the most familiar example. A table with hundreds of thousands of tiny objects creates extra request overhead, bloats manifests or logs, and reduces scan efficiency. Compaction is therefore not just a storage cleanup task. It is metadata maintenance as well. The file set becomes more manageable for both readers and the table metadata layer.
+
+Commit contention is another common issue. If many independent jobs target the same hot table, optimistic concurrency can degrade into frequent retries. The system remains correct, but throughput and latency suffer. This is often a workload-design problem as much as a format problem: too many writers are attempting to publish overlapping table state too often.
+
+Metadata bloat is a quieter but important risk. Snapshots accumulate. Manifests multiply. Transaction logs grow. Checkpoints help, and snapshot expiration or manifest compaction helps, but the table metadata path needs routine maintenance just like the data path does.
+
+Catalog dependencies matter too. A table format may be open, but queries still depend on a functioning catalog resolution path, correct permissions, and consistent metadata locations. If the catalog is unavailable, misconfigured, or stale, data files sitting safely in storage do not automatically become a usable table.
+
+This is one reason practitioners should stop talking about metadata as though it were only descriptive overhead. At lakehouse scale, metadata services are part of the serving path.
+
+## Planning
+
+The most important systems consequence is what happens before compute starts.
+
+Query engines do not begin by downloading every file under a prefix and hoping to optimize later. In a healthy lakehouse design, they reason over metadata in layers.
+
+An engine may follow a sequence like this:
+
+1. Resolve the table in a catalog.
+2. Load the current snapshot or log-derived table version.
+3. Use manifest, log, partition, or checkpoint metadata to eliminate irrelevant files.
+4. Read file-level metadata such as Parquet statistics for the remaining candidates.
+5. Only then schedule scan and compute tasks.
+
+That sequence explains why snapshots and manifests reduce expensive listing and coordination work. They give the engine a compact authoritative summary of table membership and change history, so the planning phase can stay metadata-driven instead of storage-crawl-driven.
+
+It also clarifies the boundary between file metadata and table metadata.
+
+File metadata says, "inside this file, these row groups and column chunks exist, and these statistics describe them."
+
+Table metadata says, "for this consistent version of the table, these files are live, this schema applies, this partition spec is active, and this change history produced the current state."
+
+Without the first layer, scans are wasteful. Without the second layer, the table itself is unstable.
+
+That is why open table formats turned metadata into a distributed systems concern. Once a table spans many immutable files on object storage, correctness and efficiency both depend on authoritative metadata transitions that multiple engines can trust.
+
+Part 5 picks up from there.
+
+Once the catalog, snapshot, and file set are resolved, query engines still have to decide what computation should run at all. That next step depends on metadata again: statistics, pruning rules, and planning inputs that shape execution before the first full scan begins.

--- a/prompts/blog/metadata/chapter-guide.md
+++ b/prompts/blog/metadata/chapter-guide.md
@@ -77,6 +77,8 @@ Metadata begins coordinating producers and consumers.
 - Kafka schema registry examples
 - version compatibility examples
 - migration failures
+- official specification links for Avro, JSON Schema, and Protobuf
+- concrete schema registry tooling references with links when discussing registry operations
 
 ### Ending Hook
 
@@ -265,6 +267,7 @@ Keep each article:
 - one dominant idea,
 - one architectural escalation,
 - one memorable systems insight.
+- one opening section that may use a sentence-style heading, followed by compact section titles that fit the site sidebar table of contents.
 
 Avoid:
 

--- a/prompts/blog/metadata/part2-schema-contracts.md
+++ b/prompts/blog/metadata/part2-schema-contracts.md
@@ -33,6 +33,7 @@ Tone & style:
 - No hype or marketing language
 - Use short implementation examples where they sharpen the point
 - Treat compatibility as a systems concern, not a policy slogan
+- The first major section heading may be sentence-like if it improves the setup, but subsequent section headings should be compact enough to fit cleanly in the sidebar table of contents
 
 Structure:
 
@@ -50,6 +51,8 @@ Include:
 - At least one example of a compatible change and one incompatible change
 - A concrete streaming or event-driven example such as Kafka with a schema registry
 - A discussion of semantic compatibility, not only syntactic compatibility
+- Official links for Avro, JSON Schema, and Protobuf when those formats are introduced
+- Concrete schema registry tooling references with links, such as commonly used registry implementations, when discussing registry operations
 
 Constraints:
 

--- a/prompts/blog/metadata/part2-schema-contracts.md
+++ b/prompts/blog/metadata/part2-schema-contracts.md
@@ -1,0 +1,63 @@
+---
+type: blog
+path: /blog/metadata/part2-schema-contracts
+---
+
+Write a blog post (roughly 2,200-2,800 words) titled:
+"Types Become Contracts"
+
+You are a senior data infrastructure engineer and technical writer
+with deep experience in schema design, streaming systems, and distributed data platforms.
+
+Audience:
+
+- Software engineers, data engineers, analytics engineers, and platform architects
+- Readers already understand SQL, APIs, object storage, and distributed systems basics
+- Readers want a practical explanation of why schema evolution becomes an operational problem
+
+Purpose:
+
+- Explain how typed fields become producer-consumer contracts
+- Show why metadata becomes operational once multiple systems depend on a shared schema
+- Clarify how compatibility rules affect real systems and migrations
+
+Scope:
+
+- Focus on schema evolution, compatibility, registries, and contract enforcement
+- Use concrete comparisons between Avro, JSON Schema, and Protobuf
+- Keep the discussion implementation-oriented rather than governance-oriented
+
+Tone & style:
+
+- Neutral, explanatory, and precise
+- No hype or marketing language
+- Use short implementation examples where they sharpen the point
+- Treat compatibility as a systems concern, not a policy slogan
+
+Structure:
+
+1. Start from the boundary established in Part 1: field meaning is now explicit, but shared systems still need change control
+2. Explain why a schema becomes a contract once multiple producers and consumers depend on it
+3. Compare backward compatibility, forward compatibility, and full compatibility with concrete examples
+4. Contrast Avro, JSON Schema, and Protobuf in terms of typing, evolution rules, and operational tradeoffs
+5. Explain the role of schema registries in event streams and service integration
+6. Show migration failure modes such as renamed fields, enum expansion, optional-to-required changes, and semantic drift
+7. End by showing why contracts are still not enough once metadata starts affecting file layout and runtime performance
+
+Include:
+
+- Short schema snippets in JSON, Avro IDL, Protobuf, or similar formats
+- At least one example of a compatible change and one incompatible change
+- A concrete streaming or event-driven example such as Kafka with a schema registry
+- A discussion of semantic compatibility, not only syntactic compatibility
+
+Constraints:
+
+- Do not turn the article into a vendor comparison or product guide
+- Do not reduce the topic to generic “data contract” advocacy
+- Do not drift into legal or organizational governance language
+- Do not cover Parquet internals in depth here; reserve that for the next article
+
+Ending:
+
+Close by setting up Part 3: once data is stored in large columnar files, metadata stops being only a logical contract and starts controlling compute efficiency.

--- a/prompts/blog/metadata/part3-parquet-physical-metadata.md
+++ b/prompts/blog/metadata/part3-parquet-physical-metadata.md
@@ -1,0 +1,61 @@
+---
+type: blog
+path: /blog/metadata/part3-parquet-physical-metadata
+---
+
+Write a blog post (roughly 2,400-3,000 words) titled:
+"Parquet and the Rise of Physical Metadata"
+
+You are a senior data infrastructure engineer and technical writer
+with deep experience in file formats, analytical query engines, and columnar execution.
+
+Audience:
+
+- Software engineers, data engineers, query-engine practitioners, and platform architects
+- Readers want to understand how storage metadata directly affects runtime behavior
+
+Purpose:
+
+- Explain how metadata moves from logical schema into physical execution infrastructure
+- Show why Parquet metadata determines scan cost, pruning behavior, and interoperability
+- Make the reader see file metadata as an implementation surface, not an internal detail
+
+Scope:
+
+- Focus on Parquet internals: footer metadata, row groups, column chunks, statistics, encodings, compression, and logical versus physical types
+- Connect Parquet metadata to Arrow interoperability and vectorized execution
+- Keep the examples concrete and systems-oriented
+
+Tone & style:
+
+- Neutral, explanatory, and technically serious
+- No hype, no format tribalism, no shallow benchmarks
+- Prefer direct explanations of how metadata is read and used by engines
+
+Structure:
+
+1. Start from the Part 2 handoff: contracts describe correctness, but large-scale storage also needs performance metadata
+2. Explain the difference between logical schema metadata and physical storage metadata
+3. Walk through Parquet file structure: footer, row groups, column chunks, pages, and embedded schema information
+4. Explain how min/max statistics, null counts, and partition-adjacent metadata support pruning and predicate pushdown
+5. Discuss logical types versus physical types and why that distinction matters for interoperability
+6. Connect Parquet metadata to Arrow, vectorized reads, and selective scanning
+7. Show operational tradeoffs such as stale statistics, bad file sizing, and portability versus engine-specific optimization
+8. End by showing why metadata must become distributed when a dataset spans many files
+
+Include:
+
+- A compact explanation of the Parquet footer structure
+- Examples of row-group or column-level statistics and how an engine uses them
+- At least one example of a logical type mapped to a physical type
+- A brief comparison with simpler formats such as CSV or JSON to sharpen the contrast
+
+Constraints:
+
+- Do not turn the piece into a generic introduction to file formats
+- Do not spend much time on lakehouse catalogs or manifests yet
+- Do not oversell Parquet as universally correct for every workload
+
+Ending:
+
+Close by setting up Part 4: once metadata lives across thousands of files, snapshots, and manifests, it becomes a distributed coordination layer.

--- a/prompts/blog/metadata/part3-parquet-physical-metadata.md
+++ b/prompts/blog/metadata/part3-parquet-physical-metadata.md
@@ -31,6 +31,7 @@ Tone & style:
 - Neutral, explanatory, and technically serious
 - No hype, no format tribalism, no shallow benchmarks
 - Prefer direct explanations of how metadata is read and used by engines
+- The first major section heading may be sentence-like if it improves the setup, but subsequent section headings should be compact enough to fit cleanly in the sidebar table of contents
 
 Structure:
 
@@ -49,6 +50,7 @@ Include:
 - Examples of row-group or column-level statistics and how an engine uses them
 - At least one example of a logical type mapped to a physical type
 - A brief comparison with simpler formats such as CSV or JSON to sharpen the contrast
+- Official links for notable tools or formats mentioned, especially Apache Parquet and Apache Arrow
 
 Constraints:
 

--- a/prompts/blog/metadata/part4-lakehouse-metadata.md
+++ b/prompts/blog/metadata/part4-lakehouse-metadata.md
@@ -31,6 +31,7 @@ Tone & style:
 - Neutral, explanatory, and implementation-oriented
 - No hype or vendor positioning
 - Keep the emphasis on metadata behavior under scale, concurrency, and change
+- The first major section heading may be sentence-like if it improves the setup, but subsequent section headings should be compact enough to fit cleanly in the sidebar table of contents
 
 Structure:
 
@@ -49,6 +50,7 @@ Include:
 - One simplified Delta log example or explanation of append and commit behavior
 - A clear distinction between file metadata and table metadata
 - Practical examples of why snapshots and manifests reduce expensive listing and coordination work
+- Official links for notable tools or systems mentioned, especially Apache Iceberg, Delta Lake, and Apache Hive where relevant
 
 Constraints:
 

--- a/prompts/blog/metadata/part4-lakehouse-metadata.md
+++ b/prompts/blog/metadata/part4-lakehouse-metadata.md
@@ -1,0 +1,61 @@
+---
+type: blog
+path: /blog/metadata/part4-lakehouse-metadata
+---
+
+Write a blog post (roughly 2,500-3,200 words) titled:
+"Metadata at Lakehouse Scale"
+
+You are a senior data platform architect and technical writer
+with deep experience in open table formats, object storage, and distributed metadata systems.
+
+Audience:
+
+- Data engineers, platform architects, software engineers, and analytics infrastructure practitioners
+- Readers want a practical explanation of how lakehouse systems coordinate data safely at scale
+
+Purpose:
+
+- Explain why metadata stops being attached to a single file and becomes a dataset-wide coordination layer
+- Show how open table formats turn metadata into a distributed systems concern
+- Clarify why snapshots, manifests, transaction logs, and catalogs matter operationally
+
+Scope:
+
+- Focus on Iceberg, Delta Lake, and related lakehouse metadata layers
+- Explain manifests, snapshots, partition specs, schema evolution, concurrency control, and catalogs
+- Use Hive Metastore limitations as a contrast point, not as the main subject
+
+Tone & style:
+
+- Neutral, explanatory, and implementation-oriented
+- No hype or vendor positioning
+- Keep the emphasis on metadata behavior under scale, concurrency, and change
+
+Structure:
+
+1. Start from the Part 3 handoff: file-level metadata works until the dataset spans many files and frequent updates
+2. Explain why object storage plus many Parquet files creates coordination problems
+3. Show how Iceberg organizes metadata through manifests, manifest lists, snapshots, and table metadata files
+4. Show how Delta Lake uses transaction logs and optimistic concurrency
+5. Use Hive Metastore as an example of why older catalog patterns become insufficient under modern workload pressure
+6. Explain schema evolution, partition evolution, and atomic table state changes
+7. Discuss operational realities such as small files, commit contention, metadata bloat, and catalog dependencies
+8. End by showing that query engines reason over metadata first, before compute starts
+
+Include:
+
+- One simplified Iceberg metadata flow in prose
+- One simplified Delta log example or explanation of append and commit behavior
+- A clear distinction between file metadata and table metadata
+- Practical examples of why snapshots and manifests reduce expensive listing and coordination work
+
+Constraints:
+
+- Do not write a vendor feature matrix
+- Do not drift into a general history of data lakes
+- Do not spend most of the article on governance or discovery tooling
+
+Ending:
+
+Close by setting up Part 5: query engines consume catalogs, statistics, and pruning metadata to decide what computation should run at all.

--- a/prompts/blog/metadata/part5-query-planning-metadata.md
+++ b/prompts/blog/metadata/part5-query-planning-metadata.md
@@ -1,0 +1,61 @@
+---
+type: blog
+path: /blog/metadata/part5-query-planning-metadata
+---
+
+Write a blog post (roughly 2,200-2,900 words) titled:
+"Metadata as Query Planning"
+
+You are a senior query engine practitioner and technical writer
+with strong experience in analytical execution engines, cost-based optimization, and distributed SQL systems.
+
+Audience:
+
+- Data engineers, analytics engineers, software engineers, and platform architects
+- Readers want to understand how metadata affects the compute plan before any data is scanned
+
+Purpose:
+
+- Explain how planners and optimizers depend on metadata as an execution-planning layer
+- Show that metadata influences file pruning, partition pruning, join strategy, and cost estimation
+- Connect table metadata and statistics to actual runtime behavior in query engines
+
+Scope:
+
+- Focus on statistics, catalogs, partition maps, file pruning, lineage-adjacent metadata, and planning decisions
+- Use engines such as DuckDB, Spark, and Trino as implementation anchors where useful
+- Keep the emphasis on reasoning over metadata before execution starts
+
+Tone & style:
+
+- Neutral, explanatory, and systems-oriented
+- No hype and no generic optimizer descriptions detached from metadata
+- Prefer concrete planning examples over abstract architecture slogans
+
+Structure:
+
+1. Start from the Part 4 handoff: lakehouse tables expose rich metadata, and planners consume it before touching data files
+2. Explain what planners need from metadata: schemas, statistics, partition maps, file lists, cardinality signals, and constraints
+3. Show how partition pruning and file pruning reduce the amount of work scheduled
+4. Explain how statistics influence join order, broadcast decisions, and cost estimates
+5. Discuss how catalogs and table metadata services participate in planning
+6. Show where metadata is incomplete, stale, or misleading, and how that degrades execution quality
+7. Clarify the boundary between metadata-driven planning and runtime adaptive behavior
+8. End by showing why AI workloads need richer semantic metadata than classic query planning alone
+
+Include:
+
+- At least one SQL example that leads into a pruning or planning discussion
+- An explanation of file or partition elimination using metadata rather than full scans
+- A discussion of the limits of cost-based optimization when metadata quality is poor
+- A brief comparison across at least two engines to show different planning behaviors
+
+Constraints:
+
+- Do not turn the article into a generic SQL optimization guide
+- Do not spend most of the article explaining query execution internals unrelated to metadata
+- Do not overclaim planner intelligence when metadata is weak or stale
+
+Ending:
+
+Close by setting up Part 6: AI-native systems require metadata that captures semantics, provenance, and retrieval context, not only typed tables and file statistics.

--- a/prompts/blog/metadata/part5-query-planning-metadata.md
+++ b/prompts/blog/metadata/part5-query-planning-metadata.md
@@ -31,6 +31,7 @@ Tone & style:
 - Neutral, explanatory, and systems-oriented
 - No hype and no generic optimizer descriptions detached from metadata
 - Prefer concrete planning examples over abstract architecture slogans
+- The first major section heading may be sentence-like if it improves the setup, but subsequent section headings should be compact enough to fit cleanly in the sidebar table of contents
 
 Structure:
 
@@ -49,6 +50,7 @@ Include:
 - An explanation of file or partition elimination using metadata rather than full scans
 - A discussion of the limits of cost-based optimization when metadata quality is poor
 - A brief comparison across at least two engines to show different planning behaviors
+- Official links for notable engines, catalogs, or projects mentioned, especially DuckDB, Apache Spark, and Trino
 
 Constraints:
 

--- a/prompts/blog/metadata/part6-ai-semantic-metadata.md
+++ b/prompts/blog/metadata/part6-ai-semantic-metadata.md
@@ -1,0 +1,61 @@
+---
+type: blog
+path: /blog/metadata/part6-ai-semantic-metadata
+---
+
+Write a blog post (roughly 2,300-3,000 words) titled:
+"AI Systems Need Semantic Metadata"
+
+You are a senior AI infrastructure engineer and technical writer
+with experience in retrieval systems, feature stores, embeddings, and machine-readable semantic layers.
+
+Audience:
+
+- AI engineers, data engineers, platform architects, and software engineers building retrieval or ML systems
+- Readers want a practical explanation of why AI workloads need richer metadata than traditional analytics systems
+
+Purpose:
+
+- Explain how AI systems depend on metadata that captures semantics, provenance, and retrieval context
+- Show why typed columns and file statistics are insufficient for feature stores, vector search, and RAG pipelines
+- Connect metadata design to model quality, system safety, and operational correctness
+
+Scope:
+
+- Focus on feature metadata, embedding metadata, chunk metadata, vector filters, lineage, semantic layers, and retrieval context
+- Keep the discussion grounded in implementation details rather than speculative AI claims
+- Connect modern AI infrastructure to the earlier parts of the metadata series
+
+Tone & style:
+
+- Neutral, explanatory, and engineering-heavy
+- No hype, no generic “AI transformation” language, no product marketing
+- Treat semantics as operational infrastructure for machines, not only documentation for humans
+
+Structure:
+
+1. Start from the Part 5 handoff: classic planners use structural metadata, but AI systems need machine-readable semantic context
+2. Explain why retrieval, ranking, filtering, and feature reuse require metadata beyond schema and storage layout
+3. Cover feature store metadata: feature definitions, freshness, owner, lineage, point-in-time semantics, and serving/training consistency
+4. Cover embedding and vector metadata: source document identity, chunk boundaries, language, timestamps, access constraints, and filterable attributes
+5. Explain chunk metadata in retrieval-augmented generation systems and why it shapes recall, relevance, and grounding
+6. Discuss semantic layers and machine-readable business meaning in AI workflows
+7. Cover operational risks such as stale embeddings, broken provenance, inconsistent feature definitions, and missing policy metadata
+8. End by showing how metadata is becoming an active control layer across data and AI systems
+
+Include:
+
+- At least one concrete example of chunk or vector metadata
+- At least one feature registry style example
+- A discussion of provenance and lineage for retrieval pipelines
+- A clear explanation of why semantic metadata affects machine behavior, not only discoverability
+
+Constraints:
+
+- Do not turn the article into a general introduction to RAG
+- Do not focus on prompt engineering instead of metadata systems
+- Do not make speculative claims about agents without grounding them in existing infrastructure patterns
+
+Ending:
+
+Close by setting up Part 7: once metadata coordinates compatibility, performance, planning, and semantics, it effectively becomes the control plane.

--- a/prompts/blog/metadata/part6-ai-semantic-metadata.md
+++ b/prompts/blog/metadata/part6-ai-semantic-metadata.md
@@ -31,6 +31,7 @@ Tone & style:
 - Neutral, explanatory, and engineering-heavy
 - No hype, no generic “AI transformation” language, no product marketing
 - Treat semantics as operational infrastructure for machines, not only documentation for humans
+- The first major section heading may be sentence-like if it improves the setup, but subsequent section headings should be compact enough to fit cleanly in the sidebar table of contents
 
 Structure:
 
@@ -49,6 +50,7 @@ Include:
 - At least one feature registry style example
 - A discussion of provenance and lineage for retrieval pipelines
 - A clear explanation of why semantic metadata affects machine behavior, not only discoverability
+- Official links for notable tools or systems mentioned, such as feature stores, vector databases, lineage projects, or retrieval infrastructure where relevant
 
 Constraints:
 

--- a/prompts/blog/metadata/part7-metadata-control-plane.md
+++ b/prompts/blog/metadata/part7-metadata-control-plane.md
@@ -1,0 +1,60 @@
+---
+type: blog
+path: /blog/metadata/part7-metadata-control-plane
+---
+
+Write a blog post (roughly 2,000-2,600 words) titled:
+"Metadata as the Control Plane"
+
+You are a senior data and AI platform architect and technical writer
+with experience in orchestration, observability, governance systems, and machine-operated infrastructure.
+
+Audience:
+
+- Platform architects, senior engineers, data infrastructure practitioners, and AI systems builders
+- Readers have followed the earlier series entries and now want the synthesis
+
+Purpose:
+
+- Synthesize the series into a clear argument that metadata has become the control plane of modern data and AI systems
+- Show how description, compatibility, optimization, planning, lineage, and semantics converge into a machine-coordination layer
+- End the series with a grounded but forward-looking systems perspective
+
+Scope:
+
+- Focus on orchestration, governance-adjacent control, observability, reproducibility, active metadata, and autonomous infrastructure behavior
+- Connect data platforms and AI platforms without becoming speculative or futuristic
+- Keep the emphasis on existing implementation patterns already visible in production systems
+
+Tone & style:
+
+- Neutral, explanatory, and technically serious
+- Forward-looking but grounded
+- No sci-fi framing, no hype, no vague “platformization” language
+
+Structure:
+
+1. Briefly recap the progression of the series from field semantics to semantic metadata for AI systems
+2. Define what it means to call metadata a control plane in practical engineering terms
+3. Explain how orchestration, policy enforcement, reproducibility, observability, lineage, and execution planning increasingly depend on metadata
+4. Show how active metadata changes system behavior rather than only describing state
+5. Connect data infrastructure and AI infrastructure as converging control surfaces
+6. Discuss tradeoffs such as centralization versus federated ownership, flexibility versus guarantees, and automation versus trust
+7. End with a grounded perspective on agentic and machine-operated systems that rely on rich metadata to act safely
+
+Include:
+
+- A clear synthesis of Parts 1 through 6 without repeating them in full
+- Concrete examples of metadata driving orchestration or policy decisions
+- A discussion of observability and reproducibility as metadata problems
+- A practical explanation of active metadata or machine-operable metadata
+
+Constraints:
+
+- Do not drift into a product-category survey
+- Do not make unsupported claims about autonomous systems replacing engineers
+- Do not end with vague abstractions; keep the final argument tied to implementation realities
+
+Ending:
+
+Conclude that metadata has evolved from passive description into active machine coordination, and that this shift is already visible in modern data and AI platforms.

--- a/prompts/blog/metadata/part7-metadata-control-plane.md
+++ b/prompts/blog/metadata/part7-metadata-control-plane.md
@@ -31,6 +31,7 @@ Tone & style:
 - Neutral, explanatory, and technically serious
 - Forward-looking but grounded
 - No sci-fi framing, no hype, no vague “platformization” language
+- The first major section heading may be sentence-like if it improves the setup, but subsequent section headings should be compact enough to fit cleanly in the sidebar table of contents
 
 Structure:
 
@@ -48,6 +49,7 @@ Include:
 - Concrete examples of metadata driving orchestration or policy decisions
 - A discussion of observability and reproducibility as metadata problems
 - A practical explanation of active metadata or machine-operable metadata
+- Official links for notable tools, standards, or platforms mentioned, especially orchestration, lineage, observability, or metadata systems where relevant
 
 Constraints:
 


### PR DESCRIPTION
Introduce new articles covering schema contracts, physical metadata, and lakehouse coordination. Update prompts for clarity and coherence across the series. Each part aims to enhance understanding of metadata's role in data systems.