### PR TITLE
Add isolated Codex worktree development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ go.work.sum
 public/
 resources/
 node_modules/
+.codex-runtime/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,17 @@
 
 This file defines how generative AI services should work in this repository.
 
+## Codex Worktree Development
+
+- Use a dedicated Git worktree and branch for each independent Codex task. Do not run unrelated tasks in the same worktree.
+- Keep mutable runtime state isolated. Each worktree owns its dependencies, `.codex-runtime/` directory, Hugo process, port, PID, and logs. Never reuse or stop another worktree's runtime state.
+- Use `pnpm` as the package manager. After creating or entering a new worktree, run `pnpm codex:setup`; it installs dependencies with the frozen lockfile and starts that worktree's preview server.
+- Share only immutable or download caches, such as the pnpm store and Hugo or Go module caches, when useful.
+- Run one Hugo development server per active worktree. The Codex lifecycle scripts dynamically allocate a unique localhost port and print the preview URL.
+- Use Oxfmt for formatting and formatting checks. Run `pnpm format` after making changes.
+- Verify rendered documentation changes in a browser through the worktree-specific preview URL.
+- Before completing any task, run `pnpm lint`, run `pnpm build`, and validate the relevant behavior. For documentation changes, confirm that the development server responds successfully and inspect the affected page in the browser.
+
 ## Mission
 
 This repository is a Hugo-based knowledge site for technical documentation and blog posts about software engineering, data, and AI. AI services operating here should primarily help by writing high-quality prompt files for downstream writing agents, not by defaulting to full article generation.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,13 @@
   "main": "index.js",
   "scripts": {
     "server": "hugo server --minify",
+    "build": "hugo --minify",
     "format": "oxfmt .",
-    "lint": "oxfmt --check ."
+    "lint": "oxfmt --check .",
+    "check": "pnpm lint && pnpm build",
+    "codex:setup": "./scripts/codex/setup.sh",
+    "codex:server": "./scripts/codex/server.sh",
+    "codex:stop": "./scripts/codex/stop.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/codex/server.sh
+++ b/scripts/codex/server.sh
@@ -12,6 +12,9 @@ MAX_PORT=14999
 
 mkdir -p "$RUNTIME"
 
+command -v hugo >/dev/null 2>&1 || { printf 'hugo is required (https://gohugo.io/).\n' >&2; exit 1; }
+command -v curl >/dev/null 2>&1 || { printf 'curl is required for Hugo readiness checks.\n' >&2; exit 1; }
+
 is_our_server() {
   pid=$1
   port=$2
@@ -32,9 +35,13 @@ is_ready() {
 if [ -f "$PID_FILE" ] && [ -f "$PORT_FILE" ]; then
   pid=$(cat "$PID_FILE")
   port=$(cat "$PORT_FILE")
-  if is_our_server "$pid" "$port" && is_ready "$port"; then
-    printf 'Hugo server is already running at http://127.0.0.1:%s/\n' "$port"
-    exit 0
+  if is_our_server "$pid" "$port"; then
+    if is_ready "$port"; then
+      printf 'Hugo server is already running at http://127.0.0.1:%s/\n' "$port"
+      exit 0
+    fi
+    printf 'Hugo server process %s is running on port %s but is not responding; see %s or run pnpm codex:stop.\n' "$pid" "$port" "$LOG_FILE" >&2
+    exit 1
   fi
 fi
 
@@ -56,7 +63,7 @@ while [ "$port" -le "$MAX_PORT" ]; do
     if [ "$candidate" -lt "$MIN_PORT" ] || [ "$candidate" -gt "$MAX_PORT" ]; then
       candidate=$port
     fi
-    port=$((candidate + 1))
+port=$MIN_PORT
   else
     port=$((port + 1))
   fi

--- a/scripts/codex/server.sh
+++ b/scripts/codex/server.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+
+set -eu
+
+ROOT=$(git rev-parse --show-toplevel)
+RUNTIME="$ROOT/.codex-runtime"
+PID_FILE="$RUNTIME/hugo.pid"
+PORT_FILE="$RUNTIME/hugo.port"
+LOG_FILE="$RUNTIME/hugo.log"
+MIN_PORT=14100
+MAX_PORT=14999
+
+mkdir -p "$RUNTIME"
+
+is_our_server() {
+  pid=$1
+  port=$2
+
+  kill -0 "$pid" 2>/dev/null || return 1
+  command=$(ps -p "$pid" -o command= 2>/dev/null || true)
+  case "$command" in
+    *hugo*server*"--port $port"*"--source $ROOT"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_ready() {
+  curl --fail --silent --show-error --max-time 2 \
+    "http://127.0.0.1:$1/" >/dev/null 2>&1
+}
+
+if [ -f "$PID_FILE" ] && [ -f "$PORT_FILE" ]; then
+  pid=$(cat "$PID_FILE")
+  port=$(cat "$PORT_FILE")
+  if is_our_server "$pid" "$port" && is_ready "$port"; then
+    printf 'Hugo server is already running at http://127.0.0.1:%s/\n' "$port"
+    exit 0
+  fi
+fi
+
+rm -f "$PID_FILE"
+preferred_port=""
+if [ -f "$PORT_FILE" ]; then
+  preferred_port=$(cat "$PORT_FILE")
+fi
+
+port=$MIN_PORT
+while [ "$port" -le "$MAX_PORT" ]; do
+  candidate=$port
+  if [ -n "$preferred_port" ]; then
+    candidate=$preferred_port
+    preferred_port=""
+    case "$candidate" in
+      ''|*[!0-9]*) candidate=$port ;;
+    esac
+    if [ "$candidate" -lt "$MIN_PORT" ] || [ "$candidate" -gt "$MAX_PORT" ]; then
+      candidate=$port
+    fi
+    port=$((candidate + 1))
+  else
+    port=$((port + 1))
+  fi
+
+  : >"$LOG_FILE"
+  (
+    cd "$ROOT"
+    exec nohup hugo server --minify \
+      --bind 127.0.0.1 \
+      --port "$candidate" \
+      --baseURL "http://127.0.0.1:$candidate/" \
+      --source "$ROOT"
+  ) >>"$LOG_FILE" 2>&1 &
+  pid=$!
+
+  attempts=0
+  while [ "$attempts" -lt 60 ]; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    if is_ready "$candidate" && kill -0 "$pid" 2>/dev/null; then
+      printf '%s\n' "$pid" >"$PID_FILE.tmp"
+      printf '%s\n' "$candidate" >"$PORT_FILE.tmp"
+      mv "$PID_FILE.tmp" "$PID_FILE"
+      mv "$PORT_FILE.tmp" "$PORT_FILE"
+      printf 'Hugo server started at http://127.0.0.1:%s/\n' "$candidate"
+      exit 0
+    fi
+    sleep 0.25
+    attempts=$((attempts + 1))
+  done
+
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    printf 'Hugo did not become ready on port %s; see %s\n' "$candidate" "$LOG_FILE" >&2
+    exit 1
+  fi
+
+  wait "$pid" 2>/dev/null || true
+done
+
+printf 'No available port in range %s-%s.\n' "$MIN_PORT" "$MAX_PORT" >&2
+exit 1

--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+ROOT=$(git rev-parse --show-toplevel)
+mkdir -p "$ROOT/.codex-runtime"
+
+cd "$ROOT"
+CI=true pnpm install --frozen-lockfile
+exec "$ROOT/scripts/codex/server.sh"

--- a/scripts/codex/stop.sh
+++ b/scripts/codex/stop.sh
@@ -7,8 +7,14 @@ RUNTIME="$ROOT/.codex-runtime"
 PID_FILE="$RUNTIME/hugo.pid"
 PORT_FILE="$RUNTIME/hugo.port"
 
-if [ ! -f "$PID_FILE" ] || [ ! -f "$PORT_FILE" ]; then
-  printf 'No Hugo server is recorded for this worktree.\n'
+if [ ! -f "$PID_FILE" ]; then
+  printf 'No Hugo server PID is recorded for this worktree.\n'
+  exit 0
+fi
+
+if [ ! -f "$PORT_FILE" ]; then
+  rm -f "$PID_FILE"
+  printf 'Removed a stale PID file (missing port); no matching server was stopped.\n'
   exit 0
 fi
 
@@ -29,7 +35,7 @@ case "$command" in
       exit 1
     fi
     rm -f "$PID_FILE"
-    printf 'Stopped Hugo server on http://127.0.0.1:%s/.\n' "$port"
+    printf 'Stopped Hugo server on http://127.0.0.1:%s/\n' "$port"
     ;;
   *)
     rm -f "$PID_FILE"

--- a/scripts/codex/stop.sh
+++ b/scripts/codex/stop.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -eu
+
+ROOT=$(git rev-parse --show-toplevel)
+RUNTIME="$ROOT/.codex-runtime"
+PID_FILE="$RUNTIME/hugo.pid"
+PORT_FILE="$RUNTIME/hugo.port"
+
+if [ ! -f "$PID_FILE" ] || [ ! -f "$PORT_FILE" ]; then
+  printf 'No Hugo server is recorded for this worktree.\n'
+  exit 0
+fi
+
+pid=$(cat "$PID_FILE")
+port=$(cat "$PORT_FILE")
+command=$(ps -p "$pid" -o command= 2>/dev/null || true)
+
+case "$command" in
+  *hugo*server*"--port $port"*"--source $ROOT"*)
+    kill "$pid"
+    attempts=0
+    while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 20 ]; do
+      sleep 0.25
+      attempts=$((attempts + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      printf 'Hugo server %s did not stop; leaving its runtime files intact.\n' "$pid" >&2
+      exit 1
+    fi
+    rm -f "$PID_FILE"
+    printf 'Stopped Hugo server on http://127.0.0.1:%s/.\n' "$port"
+    ;;
+  *)
+    rm -f "$PID_FILE"
+    printf 'Removed a stale PID file; no matching server was stopped.\n'
+    ;;
+esac


### PR DESCRIPTION
## Summary

- document the repository's worktree-isolated Codex development workflow
- add idempotent setup, Hugo server, and shutdown scripts
- dynamically allocate localhost ports from 14100–14999 and keep PID, port, and logs under each worktree's `.codex-runtime`
- add pnpm commands for setup, server lifecycle, formatting checks, and production builds

## Why

Multiple Codex tasks need to run concurrently without sharing mutable runtime state or interfering with another worktree's Hugo server.

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm build`
- shell syntax and Git whitespace checks
- Hugo HTTP readiness check at the allocated worktree URL
- repeated `pnpm codex:server` reused the same PID
- repeated `pnpm codex:stop` completed safely