### PR TITLE
feat: add safe worktree cleanup skill

### DIFF
--- a/.github/skills/cleanup-worktrees/SKILL.md
+++ b/.github/skills/cleanup-worktrees/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: cleanup-worktrees
+description: Safely inspect and clean up linked Git worktrees and local branches after GitHub pull requests are merged or closed. Use when parallel Codex or developer tasks have left stale worktrees, when the user asks to audit or prune completed-PR branches, or when cleanup must account for dirty worktrees and squash/rebase merges. Do not use for general repository maintenance or to delete worktrees that are unrelated to completed GitHub pull requests.
+---
+
+# Clean Up Git Worktrees
+
+Use the bundled `scripts/cleanup_worktrees.py` helper. Keep inspection and deletion separate; always inspect first.
+
+## Preconditions
+
+1. Run from any worktree belonging to the target repository.
+2. Require `git` and `gh`; verify `gh auth status` before querying GitHub.
+3. Prefer fresh remote state. Run `git fetch --prune` only after confirming the repository's remote is the intended one, or pass `--fetch` to the helper.
+4. Do not use this skill while another process is creating, moving, or removing worktrees.
+
+## Inspect
+
+Run:
+
+```bash
+python3 .github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
+```
+
+The helper defaults to dry-run reporting and makes no deletions. It parses `git worktree list --porcelain`, checks every linked worktree with `git status --porcelain`, looks up PRs with `gh pr list --head <branch> --state all`, and prints `SAFE`, `KEEP`, and `REVIEW` groups.
+
+Interpret the groups as follows:
+
+- `SAFE`: the linked worktree is clean, its PR is `MERGED` or `CLOSED`, and the local branch tip exactly matches the PR's recorded `headRefOid`.
+- `KEEP`: the primary worktree or a worktree whose associated PR is `OPEN`.
+- `REVIEW`: any dirty worktree, detached HEAD, missing PR, failed GitHub lookup, missing PR head evidence, multiple ambiguous PRs, or local tip that differs from the PR head.
+
+Never promote `KEEP` or `REVIEW` to `SAFE` merely because the remote branch is missing or `git branch --merged` reports the branch as merged.
+
+## Confirm and remove
+
+Show the complete dry-run report to the user. Obtain explicit confirmation naming the `SAFE` paths to remove. Then run one apply command with only those exact paths:
+
+```bash
+python3 .github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py \
+  --apply \
+  --worktree /absolute/path/to/task-a \
+  --worktree /absolute/path/to/task-b
+```
+
+The helper rescans immediately before deletion and refuses any selected path that is no longer `SAFE`. It prompts once more unless `--yes` is passed. Use `--yes` only when the user already explicitly approved the exact paths in the same interaction.
+
+For each still-safe selection, the helper runs `git worktree remove`, then deletes the local branch. It first tries `git branch -d`. If Git rejects that command after a squash or rebase merge, it may use `git branch -D` because the completed PR, clean worktree, and exact PR-head match were revalidated. Finally it runs `git worktree prune` if at least one worktree was removed.
+
+## Safety model
+
+- Always preserve the primary worktree, regardless of its branch or PR state.
+- Treat staged, unstaged, and untracked files as dirty and classify the worktree as `REVIEW`.
+- Treat an `OPEN` PR as `KEEP`.
+- Treat `MERGED` and `CLOSED` PRs only as candidates; require a clean worktree and exact local-tip/PR-head equality.
+- Treat no PR or an unavailable GitHub state as `REVIEW`.
+- Use the PR head OID as evidence that the branch commits are represented by the PR. This supports squash and rebase merges without requiring the original commits to be ancestors of the base branch.
+- Never manually delete `.git/worktrees` metadata.
+- Never pass `--force` to `git worktree remove`.
+
+## Examples
+
+Audit all worktrees without fetching or deleting:
+
+```bash
+python3 .github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
+```
+
+Refresh remote refs, then audit:
+
+```bash
+python3 .github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py --fetch
+```
+
+Remove one previously reported safe worktree after confirmation:
+
+```bash
+python3 .github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py \
+  --apply --worktree /private/tmp/project-task
+```
+
+Do not use this workflow to recover corrupted worktree metadata, delete arbitrary directories, clean untracked files, or decide whether unpublished work is disposable. Handle those as separate, explicitly authorized tasks.

--- a/.github/skills/cleanup-worktrees/agents/openai.yaml
+++ b/.github/skills/cleanup-worktrees/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Cleanup Git Worktrees"
+  short_description: "Safely inspect and remove completed PR worktrees"
+  default_prompt: "Use $cleanup-worktrees to inspect stale Git worktrees and safely clean up completed pull request branches."

--- a/.github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
+++ b/.github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Conservatively inspect and remove completed-PR Git worktrees."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+@dataclass
+class Worktree:
+    path: str
+    oid: str = ""
+    branch: str | None = None
+    primary: bool = False
+
+
+@dataclass
+class Result:
+    worktree: Worktree
+    category: str
+    reason: str
+    pr_number: int | None = None
+    pr_state: str | None = None
+
+
+class CommandError(RuntimeError):
+    pass
+
+
+def run(args: Sequence[str], cwd: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(args, cwd=cwd, text=True, capture_output=True)
+    if check and proc.returncode:
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"exit {proc.returncode}"
+        raise CommandError(f"{' '.join(args)}: {detail}")
+    return proc
+
+
+def parse_worktrees(text: str) -> list[Worktree]:
+    records: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in text.splitlines() + [""]:
+        if not line:
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+
+    worktrees: list[Worktree] = []
+    for index, record in enumerate(records):
+        branch_ref = record.get("branch")
+        branch = branch_ref.removeprefix("refs/heads/") if branch_ref else None
+        worktrees.append(
+            Worktree(
+                path=record["worktree"],
+                oid=record.get("HEAD", ""),
+                branch=branch,
+                primary=index == 0,
+            )
+        )
+    return worktrees
+
+
+def find_pr(repo: str, branch: str) -> tuple[dict | None, str | None]:
+    fields = "number,state,headRefOid,url,updatedAt"
+    proc = run(
+        ["gh", "pr", "list", "--head", branch, "--state", "all", "--limit", "100", "--json", fields],
+        cwd=repo,
+        check=False,
+    )
+    if proc.returncode:
+        return None, proc.stderr.strip() or proc.stdout.strip() or "GitHub lookup failed"
+    try:
+        prs = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return None, f"invalid GitHub response: {exc}"
+    if not prs:
+        return None, None
+    open_prs = [pr for pr in prs if pr.get("state") == "OPEN"]
+    candidates = open_prs or prs
+    candidates.sort(key=lambda pr: pr.get("updatedAt", ""), reverse=True)
+    if len(candidates) > 1 and candidates[0].get("updatedAt") == candidates[1].get("updatedAt"):
+        return None, "multiple ambiguous PRs found"
+    return candidates[0], None
+
+
+def classify(repo: str, worktree: Worktree) -> Result:
+    if worktree.primary:
+        return Result(worktree, "KEEP", "primary worktree")
+    if not worktree.branch:
+        return Result(worktree, "REVIEW", "detached HEAD or no local branch")
+
+    status = run(["git", "status", "--porcelain", "--untracked-files=all"], worktree.path, check=False)
+    if status.returncode:
+        return Result(worktree, "REVIEW", "cannot inspect worktree status")
+    if status.stdout:
+        return Result(worktree, "REVIEW", "uncommitted, staged, or untracked changes")
+
+    pr, error = find_pr(repo, worktree.branch)
+    if error:
+        return Result(worktree, "REVIEW", error)
+    if pr is None:
+        return Result(worktree, "REVIEW", "no associated PR found")
+
+    number = pr.get("number")
+    state = pr.get("state")
+    if state == "OPEN":
+        return Result(worktree, "KEEP", "PR is open", number, state)
+    if state not in {"MERGED", "CLOSED"}:
+        return Result(worktree, "REVIEW", f"unknown PR state: {state}", number, state)
+
+    pr_head = pr.get("headRefOid")
+    if not pr_head:
+        return Result(worktree, "REVIEW", "PR head OID is unavailable", number, state)
+    if worktree.oid != pr_head:
+        return Result(worktree, "REVIEW", "local branch tip differs from PR head", number, state)
+    return Result(worktree, "SAFE", "clean and local tip matches completed PR head", number, state)
+
+
+def scan(repo: str) -> list[Result]:
+    listing = run(["git", "worktree", "list", "--porcelain"], repo).stdout
+    return [classify(repo, wt) for wt in parse_worktrees(listing)]
+
+
+def print_report(results: Sequence[Result]) -> None:
+    print("Worktree cleanup\n")
+    for category in ("SAFE", "KEEP", "REVIEW"):
+        print(category)
+        grouped = [result for result in results if result.category == category]
+        if not grouped:
+            print("  (none)")
+        for result in grouped:
+            wt = result.worktree
+            pr = f"PR #{result.pr_number} {result.pr_state}" if result.pr_number else "no PR"
+            branch = wt.branch or "(detached)"
+            print(f"  {branch}  {pr}  {wt.path}  — {result.reason}")
+        print()
+
+
+def remove_selected(repo: str, results: Sequence[Result], selected: Sequence[str], assume_yes: bool) -> int:
+    normalized = {str(Path(path).resolve()) for path in selected}
+    by_path = {str(Path(result.worktree.path).resolve()): result for result in results}
+    missing = sorted(normalized - by_path.keys())
+    unsafe = [by_path[path] for path in normalized & by_path.keys() if by_path[path].category != "SAFE"]
+    if missing or unsafe:
+        for path in missing:
+            print(f"Refusing unknown worktree: {path}", file=sys.stderr)
+        for result in unsafe:
+            print(f"Refusing {result.worktree.path}: now {result.category} ({result.reason})", file=sys.stderr)
+        return 2
+
+    targets = [by_path[path] for path in normalized]
+    if not targets:
+        print("No worktrees selected; nothing to remove.", file=sys.stderr)
+        return 2
+
+    print("Selected for removal:")
+    for result in targets:
+        print(f"  {result.worktree.path} ({result.worktree.branch}, PR #{result.pr_number} {result.pr_state})")
+    print("Local branch deletion may use git branch -D after the safety checks above.")
+    if not assume_yes:
+        answer = input("Type 'remove' to continue: ").strip()
+        if answer != "remove":
+            print("Cancelled.")
+            return 1
+
+    removed = 0
+    for result in targets:
+        wt = result.worktree
+        run(["git", "worktree", "remove", "--", wt.path], repo)
+        deleted = run(["git", "branch", "-d", "--", wt.branch], repo, check=False)
+        if deleted.returncode:
+            run(["git", "branch", "-D", "--", wt.branch], repo)
+        removed += 1
+        print(f"Removed {wt.path} and local branch {wt.branch}")
+    if removed:
+        run(["git", "worktree", "prune"], repo)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fetch", action="store_true", help="run git fetch --prune before inspection")
+    parser.add_argument("--apply", action="store_true", help="remove explicitly selected SAFE worktrees")
+    parser.add_argument("--worktree", action="append", default=[], help="absolute worktree path; repeat as needed")
+    parser.add_argument("--yes", action="store_true", help="skip the final typed confirmation")
+    args = parser.parse_args()
+
+    try:
+        repo = run(["git", "rev-parse", "--show-toplevel"], ".").stdout.strip()
+        if args.fetch:
+            run(["git", "fetch", "--prune"], repo)
+        results = scan(repo)
+        print_report(results)
+        if not args.apply:
+            if args.worktree or args.yes:
+                print("Note: --worktree/--yes have no effect without --apply.", file=sys.stderr)
+            return 0
+        if not args.worktree:
+            print("Refusing --apply without at least one --worktree path.", file=sys.stderr)
+            return 2
+        return remove_selected(repo, results, args.worktree, args.yes)
+    except (CommandError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
+++ b/.github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
@@ -171,6 +171,26 @@ def remove_selected(repo: str, results: Sequence[Result], selected: Sequence[str
             print("Cancelled.")
             return 1
 
+    # Re-scan immediately before deletion to revalidate safety.
+    refreshed_results = scan(repo)
+    refreshed_by_path = {str(Path(result.worktree.path).resolve()): result for result in refreshed_results}
+    refreshed_missing = sorted(normalized - refreshed_by_path.keys())
+    refreshed_unsafe = [
+        refreshed_by_path[path]
+        for path in normalized & refreshed_by_path.keys()
+        if refreshed_by_path[path].category != "SAFE"
+    ]
+    if refreshed_missing or refreshed_unsafe:
+        for path in refreshed_missing:
+            print(f"Refusing unknown worktree: {path}", file=sys.stderr)
+        for result in refreshed_unsafe:
+            print(
+                f"Refusing {result.worktree.path}: now {result.category} ({result.reason})",
+                file=sys.stderr,
+            )
+        return 2
+
+    targets = [refreshed_by_path[path] for path in normalized]
     removed = 0
     for result in targets:
         wt = result.worktree

--- a/.github/skills/cleanup-worktrees/tests/test_cleanup_worktrees.py
+++ b/.github/skills/cleanup-worktrees/tests/test_cleanup_worktrees.py
@@ -1,0 +1,125 @@
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "cleanup_worktrees.py"
+SPEC = importlib.util.spec_from_file_location("cleanup_worktrees", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, text=True, capture_output=True
+    ).stdout.strip()
+
+
+class CleanupWorktreesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.repo = self.root / "repo"
+        self.repo.mkdir()
+        git(self.repo, "init", "-b", "main")
+        git(self.repo, "config", "user.name", "Skill Test")
+        git(self.repo, "config", "user.email", "skill-test@example.invalid")
+        (self.repo / "base.txt").write_text("base\n")
+        git(self.repo, "add", "base.txt")
+        git(self.repo, "commit", "-m", "base")
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def add_worktree(self, branch: str, dirty: bool = False) -> tuple[Path, str]:
+        path = self.root / branch
+        git(self.repo, "worktree", "add", "-b", branch, str(path))
+        (path / f"{branch}.txt").write_text(f"{branch}\n")
+        git(path, "add", f"{branch}.txt")
+        git(path, "commit", "-m", branch)
+        oid = git(path, "rev-parse", "HEAD")
+        if dirty:
+            (path / "untracked.txt").write_text("preserve me\n")
+        return path, oid
+
+    def test_classification_matrix(self) -> None:
+        merged_path, merged_oid = self.add_worktree("merged")
+        closed_path, closed_oid = self.add_worktree("closed")
+        open_path, open_oid = self.add_worktree("open")
+        dirty_path, dirty_oid = self.add_worktree("dirty", dirty=True)
+        no_pr_path, _ = self.add_worktree("no-pr")
+        squash_path, squash_oid = self.add_worktree("squash")
+
+        prs = {
+            "merged": ({"number": 1, "state": "MERGED", "headRefOid": merged_oid}, None),
+            "closed": ({"number": 2, "state": "CLOSED", "headRefOid": closed_oid}, None),
+            "open": ({"number": 3, "state": "OPEN", "headRefOid": open_oid}, None),
+            "dirty": ({"number": 4, "state": "MERGED", "headRefOid": dirty_oid}, None),
+            "no-pr": (None, None),
+            # This commit is deliberately not merged into main; PR evidence is sufficient.
+            "squash": ({"number": 5, "state": "MERGED", "headRefOid": squash_oid}, None),
+        }
+        with patch.object(MODULE, "find_pr", side_effect=lambda _repo, branch: prs[branch]):
+            results = MODULE.scan(str(self.repo))
+
+        by_branch = {result.worktree.branch: result for result in results}
+        self.assertEqual("KEEP", by_branch["main"].category)
+        self.assertEqual("primary worktree", by_branch["main"].reason)
+        self.assertEqual("SAFE", by_branch["merged"].category)
+        self.assertEqual("SAFE", by_branch["closed"].category)
+        self.assertEqual("KEEP", by_branch["open"].category)
+        self.assertEqual("REVIEW", by_branch["dirty"].category)
+        self.assertEqual("REVIEW", by_branch["no-pr"].category)
+        self.assertEqual("SAFE", by_branch["squash"].category)
+        self.assertFalse(
+            subprocess.run(
+                ["git", "merge-base", "--is-ancestor", squash_oid, "main"], cwd=self.repo
+            ).returncode
+            == 0
+        )
+        self.assertTrue(dirty_path.exists())
+        self.assertTrue(no_pr_path.exists())
+        self.assertTrue(open_path.exists())
+        self.assertTrue(merged_path.exists())
+        self.assertTrue(closed_path.exists())
+        self.assertTrue(squash_path.exists())
+
+    def test_apply_removes_only_explicit_safe_worktree(self) -> None:
+        safe_path, safe_oid = self.add_worktree("safe")
+        dirty_path, dirty_oid = self.add_worktree("dirty", dirty=True)
+        prs = {
+            "safe": ({"number": 10, "state": "MERGED", "headRefOid": safe_oid}, None),
+            "dirty": ({"number": 11, "state": "MERGED", "headRefOid": dirty_oid}, None),
+        }
+        with patch.object(MODULE, "find_pr", side_effect=lambda _repo, branch: prs[branch]):
+            results = MODULE.scan(str(self.repo))
+            code = MODULE.remove_selected(str(self.repo), results, [str(safe_path)], True)
+
+        self.assertEqual(0, code)
+        self.assertFalse(safe_path.exists())
+        self.assertNotIn("safe", git(self.repo, "branch", "--format=%(refname:short)").splitlines())
+        self.assertTrue(dirty_path.exists())
+        self.assertIn("dirty", git(self.repo, "branch", "--format=%(refname:short)").splitlines())
+
+    def test_apply_refuses_review_worktree(self) -> None:
+        dirty_path, dirty_oid = self.add_worktree("dirty", dirty=True)
+        with patch.object(
+            MODULE,
+            "find_pr",
+            return_value=({"number": 12, "state": "MERGED", "headRefOid": dirty_oid}, None),
+        ):
+            results = MODULE.scan(str(self.repo))
+            code = MODULE.remove_selected(str(self.repo), results, [str(dirty_path)], True)
+
+        self.assertEqual(2, code)
+        self.assertTrue(dirty_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a reusable `cleanup-worktrees` Codex skill
- classify linked worktrees as `SAFE`, `KEEP`, or `REVIEW` using Git status and GitHub PR evidence
- require explicit path selection and confirmation before deletion
- cover merged, closed, open, dirty, no-PR, squash-merged, and primary-worktree scenarios with disposable tests

## Why

Parallel Codex tasks can leave local worktrees and branches after their pull requests are completed in GitHub. This skill provides a conservative cleanup workflow that protects uncommitted and local-only work, including branches merged with squash or rebase strategies.

## Safety

- never removes the primary worktree
- treats staged, unstaged, and untracked content as `REVIEW`
- keeps open pull requests
- requires completed PR state and an exact local-tip/PR-head match
- defaults to dry-run inspection and revalidates before deletion

## Validation

- `python3 -m unittest discover -s .github/skills/cleanup-worktrees/tests -v`
- official Agent Skill validator
- `pnpm format`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
