### PR TITLE
Allow cleanup of merged ancestor worktrees

### DIFF
--- a/.github/skills/cleanup-worktrees/SKILL.md
+++ b/.github/skills/cleanup-worktrees/SKILL.md
@@ -26,11 +26,13 @@ The helper defaults to dry-run reporting and makes no deletions. It parses `git 
 
 Interpret the groups as follows:
 
-- `SAFE`: the linked worktree is clean, its PR is `MERGED` or `CLOSED`, and the local branch tip exactly matches the PR's recorded `headRefOid`.
+- `SAFE`: the linked worktree is clean and either:
+  - its `MERGED` or `CLOSED` PR records a `headRefOid` exactly matching the local branch tip; or
+  - its PR is `MERGED` and the local branch tip is an ancestor of the fetched `origin/<baseRefName>` history. This covers GitHub-side commits added to the PR after the local checkout stopped updating.
 - `KEEP`: the primary worktree or a worktree whose associated PR is `OPEN`.
-- `REVIEW`: any dirty worktree, detached HEAD, missing PR, failed GitHub lookup, missing PR head evidence, multiple ambiguous PRs, or local tip that differs from the PR head.
+- `REVIEW`: any dirty worktree, detached HEAD, missing PR, failed GitHub lookup, missing PR head evidence, multiple ambiguous PRs, or divergent local tip that neither matches the PR head nor appears in the merged base history.
 
-Never promote `KEEP` or `REVIEW` to `SAFE` merely because the remote branch is missing or `git branch --merged` reports the branch as merged.
+Never promote `KEEP` or `REVIEW` to `SAFE` merely because the remote branch is missing or `git branch --merged` reports the branch as merged. The ancestry fallback requires a GitHub-confirmed `MERGED` PR and tests the local tip against the PR's fetched remote base ref.
 
 ## Confirm and remove
 
@@ -52,9 +54,12 @@ For each still-safe selection, the helper runs `git worktree remove`, then delet
 - Always preserve the primary worktree, regardless of its branch or PR state.
 - Treat staged, unstaged, and untracked files as dirty and classify the worktree as `REVIEW`.
 - Treat an `OPEN` PR as `KEEP`.
-- Treat `MERGED` and `CLOSED` PRs only as candidates; require a clean worktree and exact local-tip/PR-head equality.
+- Treat `MERGED` and `CLOSED` PRs only as candidates; require a clean worktree.
+- Accept exact local-tip/PR-head equality for either completed PR state.
+- When a `MERGED` PR head contains later GitHub-side edits, also accept a local tip that is an ancestor of the fetched `origin/<baseRefName>`. Do not use this ancestry fallback for merely `CLOSED` PRs.
 - Treat no PR or an unavailable GitHub state as `REVIEW`.
 - Use the PR head OID as evidence that the branch commits are represented by the PR. This supports squash and rebase merges without requiring the original commits to be ancestors of the base branch.
+- Use merged-base ancestry as separate evidence that an older local branch tip was incorporated before later commits were added to the PR on GitHub.
 - Never manually delete `.git/worktrees` metadata.
 - Never pass `--force` to `git worktree remove`.
 

--- a/.github/skills/cleanup-worktrees/SKILL.md
+++ b/.github/skills/cleanup-worktrees/SKILL.md
@@ -30,7 +30,7 @@ Interpret the groups as follows:
   - its `MERGED` or `CLOSED` PR records a `headRefOid` exactly matching the local branch tip; or
   - its PR is `MERGED` and the local branch tip is an ancestor of the fetched `origin/<baseRefName>` history. This covers GitHub-side commits added to the PR after the local checkout stopped updating.
 - `KEEP`: the primary worktree or a worktree whose associated PR is `OPEN`.
-- `REVIEW`: any dirty worktree, detached HEAD, missing PR, failed GitHub lookup, missing PR head evidence, multiple ambiguous PRs, or divergent local tip that neither matches the PR head nor appears in the merged base history.
+- `REVIEW`: any dirty worktree, detached HEAD, missing PR, failed GitHub lookup, missing PR head evidence, multiple ambiguous PRs, a `CLOSED` PR whose head differs from the local tip, an unavailable merged-PR base ref, or a merged-PR local tip that is not in the base history.
 
 Never promote `KEEP` or `REVIEW` to `SAFE` merely because the remote branch is missing or `git branch --merged` reports the branch as merged. The ancestry fallback requires a GitHub-confirmed `MERGED` PR and tests the local tip against the PR's fetched remote base ref.
 

--- a/.github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
+++ b/.github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
@@ -100,6 +100,11 @@ def is_ancestor(repo: str, ancestor: str, descendant: str) -> bool:
     return proc.returncode == 0
 
 
+def ref_exists(repo: str, ref: str) -> bool:
+    proc = run(["git", "rev-parse", "--verify", "--quiet", ref], cwd=repo, check=False)
+    return proc.returncode == 0
+
+
 def classify(repo: str, worktree: Worktree) -> Result:
     if worktree.primary:
         return Result(worktree, "KEEP", "primary worktree")
@@ -131,9 +136,24 @@ def classify(repo: str, worktree: Worktree) -> Result:
     if worktree.oid == pr_head:
         return Result(worktree, "SAFE", "clean and local tip matches completed PR head", number, state)
 
+    if state == "CLOSED":
+        return Result(worktree, "REVIEW", "local branch tip differs from closed PR head", number, state)
+
     base = pr.get("baseRefName")
-    remote_base = f"refs/remotes/origin/{base}" if base else ""
-    if state == "MERGED" and remote_base and is_ancestor(repo, worktree.oid, remote_base):
+    if not base:
+        return Result(worktree, "REVIEW", "local tip differs from PR head and PR base is unavailable", number, state)
+
+    remote_base = f"refs/remotes/origin/{base}"
+    if not ref_exists(repo, remote_base):
+        return Result(
+            worktree,
+            "REVIEW",
+            f"merged PR base ref is unavailable ({remote_base}); run again with --fetch",
+            number,
+            state,
+        )
+
+    if is_ancestor(repo, worktree.oid, remote_base):
         return Result(
             worktree,
             "SAFE",
@@ -142,8 +162,6 @@ def classify(repo: str, worktree: Worktree) -> Result:
             state,
         )
 
-    if state == "MERGED" and not base:
-        return Result(worktree, "REVIEW", "local tip differs from PR head and PR base is unavailable", number, state)
     return Result(
         worktree,
         "REVIEW",

--- a/.github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
+++ b/.github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
@@ -143,7 +143,7 @@ def classify(repo: str, worktree: Worktree) -> Result:
     if not base:
         return Result(worktree, "REVIEW", "local tip differs from PR head and PR base is unavailable", number, state)
 
-    remote_base = f"refs/remotes/origin/{base}"
+    remote_base = f"origin/{base}"
     if not ref_exists(repo, remote_base):
         return Result(
             worktree,

--- a/.github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
+++ b/.github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
@@ -69,7 +69,7 @@ def parse_worktrees(text: str) -> list[Worktree]:
 
 
 def find_pr(repo: str, branch: str) -> tuple[dict | None, str | None]:
-    fields = "number,state,headRefOid,url,updatedAt"
+    fields = "number,state,headRefOid,baseRefName,url,updatedAt"
     proc = run(
         ["gh", "pr", "list", "--head", branch, "--state", "all", "--limit", "100", "--json", fields],
         cwd=repo,
@@ -89,6 +89,15 @@ def find_pr(repo: str, branch: str) -> tuple[dict | None, str | None]:
     if len(candidates) > 1 and candidates[0].get("updatedAt") == candidates[1].get("updatedAt"):
         return None, "multiple ambiguous PRs found"
     return candidates[0], None
+
+
+def is_ancestor(repo: str, ancestor: str, descendant: str) -> bool:
+    proc = run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=repo,
+        check=False,
+    )
+    return proc.returncode == 0
 
 
 def classify(repo: str, worktree: Worktree) -> Result:
@@ -119,9 +128,29 @@ def classify(repo: str, worktree: Worktree) -> Result:
     pr_head = pr.get("headRefOid")
     if not pr_head:
         return Result(worktree, "REVIEW", "PR head OID is unavailable", number, state)
-    if worktree.oid != pr_head:
-        return Result(worktree, "REVIEW", "local branch tip differs from PR head", number, state)
-    return Result(worktree, "SAFE", "clean and local tip matches completed PR head", number, state)
+    if worktree.oid == pr_head:
+        return Result(worktree, "SAFE", "clean and local tip matches completed PR head", number, state)
+
+    base = pr.get("baseRefName")
+    remote_base = f"refs/remotes/origin/{base}" if base else ""
+    if state == "MERGED" and remote_base and is_ancestor(repo, worktree.oid, remote_base):
+        return Result(
+            worktree,
+            "SAFE",
+            f"clean and local tip is contained in merged PR base history ({remote_base})",
+            number,
+            state,
+        )
+
+    if state == "MERGED" and not base:
+        return Result(worktree, "REVIEW", "local tip differs from PR head and PR base is unavailable", number, state)
+    return Result(
+        worktree,
+        "REVIEW",
+        "local branch tip differs from PR head and is not contained in merged PR base history",
+        number,
+        state,
+    )
 
 
 def scan(repo: str) -> list[Result]:

--- a/.github/skills/cleanup-worktrees/tests/test_cleanup_worktrees.py
+++ b/.github/skills/cleanup-worktrees/tests/test_cleanup_worktrees.py
@@ -107,6 +107,63 @@ class CleanupWorktreesTest(unittest.TestCase):
         self.assertTrue(dirty_path.exists())
         self.assertIn("dirty", git(self.repo, "branch", "--format=%(refname:short)").splitlines())
 
+    def test_merged_pr_accepts_older_local_tip_contained_in_base_history(self) -> None:
+        path, local_oid = self.add_worktree("web-edited")
+        (path / "web-edit.txt").write_text("edited on GitHub\n")
+        git(path, "add", "web-edit.txt")
+        git(path, "commit", "-m", "web edit")
+        pr_head_oid = git(path, "rev-parse", "HEAD")
+
+        git(self.repo, "merge", "--no-ff", "web-edited", "-m", "merge web-edited")
+        git(self.repo, "update-ref", "refs/remotes/origin/main", "main")
+        git(path, "reset", "--hard", local_oid)
+
+        with patch.object(
+            MODULE,
+            "find_pr",
+            return_value=(
+                {
+                    "number": 13,
+                    "state": "MERGED",
+                    "headRefOid": pr_head_oid,
+                    "baseRefName": "main",
+                },
+                None,
+            ),
+        ):
+            result = MODULE.classify(
+                str(self.repo),
+                MODULE.Worktree(path=str(path), oid=local_oid, branch="web-edited"),
+            )
+
+        self.assertEqual("SAFE", result.category)
+        self.assertIn("contained in merged PR base history", result.reason)
+
+    def test_closed_pr_does_not_use_base_ancestry_fallback(self) -> None:
+        path, local_oid = self.add_worktree("closed-behind")
+        git(self.repo, "merge", "--no-ff", "closed-behind", "-m", "merge closed-behind")
+        git(self.repo, "update-ref", "refs/remotes/origin/main", "main")
+
+        with patch.object(
+            MODULE,
+            "find_pr",
+            return_value=(
+                {
+                    "number": 14,
+                    "state": "CLOSED",
+                    "headRefOid": "0" * 40,
+                    "baseRefName": "main",
+                },
+                None,
+            ),
+        ):
+            result = MODULE.classify(
+                str(self.repo),
+                MODULE.Worktree(path=str(path), oid=local_oid, branch="closed-behind"),
+            )
+
+        self.assertEqual("REVIEW", result.category)
+
     def test_apply_refuses_review_worktree(self) -> None:
         dirty_path, dirty_oid = self.add_worktree("dirty", dirty=True)
         with patch.object(

--- a/.github/skills/cleanup-worktrees/tests/test_cleanup_worktrees.py
+++ b/.github/skills/cleanup-worktrees/tests/test_cleanup_worktrees.py
@@ -108,15 +108,26 @@ class CleanupWorktreesTest(unittest.TestCase):
         self.assertIn("dirty", git(self.repo, "branch", "--format=%(refname:short)").splitlines())
 
     def test_merged_pr_accepts_older_local_tip_contained_in_base_history(self) -> None:
-        path, local_oid = self.add_worktree("web-edited")
+        base_oid = git(self.repo, "rev-parse", "main")
+        path, first_pr_oid = self.add_worktree("web-edited")
         (path / "web-edit.txt").write_text("edited on GitHub\n")
         git(path, "add", "web-edit.txt")
         git(path, "commit", "-m", "web edit")
         pr_head_oid = git(path, "rev-parse", "HEAD")
 
+        self.assertNotEqual(base_oid, first_pr_oid)
+        self.assertNotEqual(first_pr_oid, pr_head_oid)
+        self.assertEqual(
+            0,
+            subprocess.run(
+                ["git", "merge-base", "--is-ancestor", first_pr_oid, pr_head_oid],
+                cwd=self.repo,
+            ).returncode,
+        )
+
         git(self.repo, "merge", "--no-ff", "web-edited", "-m", "merge web-edited")
         git(self.repo, "update-ref", "refs/remotes/origin/main", "main")
-        git(path, "reset", "--hard", local_oid)
+        git(path, "reset", "--hard", first_pr_oid)
 
         with patch.object(
             MODULE,
@@ -133,7 +144,7 @@ class CleanupWorktreesTest(unittest.TestCase):
         ):
             result = MODULE.classify(
                 str(self.repo),
-                MODULE.Worktree(path=str(path), oid=local_oid, branch="web-edited"),
+                MODULE.Worktree(path=str(path), oid=first_pr_oid, branch="web-edited"),
             )
 
         self.assertEqual("SAFE", result.category)
@@ -163,6 +174,30 @@ class CleanupWorktreesTest(unittest.TestCase):
             )
 
         self.assertEqual("REVIEW", result.category)
+        self.assertEqual("local branch tip differs from closed PR head", result.reason)
+
+    def test_missing_merged_base_ref_recommends_fetch(self) -> None:
+        path, local_oid = self.add_worktree("missing-base")
+        with patch.object(
+            MODULE,
+            "find_pr",
+            return_value=(
+                {
+                    "number": 15,
+                    "state": "MERGED",
+                    "headRefOid": "0" * 40,
+                    "baseRefName": "not-fetched",
+                },
+                None,
+            ),
+        ):
+            result = MODULE.classify(
+                str(self.repo),
+                MODULE.Worktree(path=str(path), oid=local_oid, branch="missing-base"),
+            )
+
+        self.assertEqual("REVIEW", result.category)
+        self.assertIn("run again with --fetch", result.reason)
 
     def test_apply_refuses_review_worktree(self) -> None:
         dirty_path, dirty_oid = self.add_worktree("dirty", dirty=True)

--- a/.github/skills/cleanup-worktrees/tests/test_cleanup_worktrees.py
+++ b/.github/skills/cleanup-worktrees/tests/test_cleanup_worktrees.py
@@ -149,6 +149,7 @@ class CleanupWorktreesTest(unittest.TestCase):
 
         self.assertEqual("SAFE", result.category)
         self.assertIn("contained in merged PR base history", result.reason)
+        self.assertIn("(origin/main)", result.reason)
 
     def test_closed_pr_does_not_use_base_ancestry_fallback(self) -> None:
         path, local_oid = self.add_worktree("closed-behind")
@@ -197,6 +198,7 @@ class CleanupWorktreesTest(unittest.TestCase):
             )
 
         self.assertEqual("REVIEW", result.category)
+        self.assertIn("(origin/not-fetched)", result.reason)
         self.assertIn("run again with --fetch", result.reason)
 
     def test_apply_refuses_review_worktree(self) -> None:


### PR DESCRIPTION
## Summary
- classify a clean worktree as SAFE when its merged PR has later GitHub-side commits but the local tip is already contained in the fetched base history
- keep exact PR-head matching as the existing safety path for merged, closed, squash, and rebase cases
- restrict the new ancestry fallback to MERGED PRs only
- document the new safety model and add positive and negative tests

## Validation
- python3 -m unittest discover -s .github/skills/cleanup-worktrees/tests -v
- python3 -m py_compile .github/skills/cleanup-worktrees/scripts/cleanup_worktrees.py
- pnpm format
- pnpm lint
- pnpm build
- git diff --check
- live dry-run classifies codex/data-quality-prompts as SAFE via origin/main ancestry